### PR TITLE
Fix access control on mega test admin route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { Button } from './components/ui/button';
 import { User as UserIcon, Book, LogOut } from 'lucide-react';
 import { api } from './api/config';
 import ProtectedRoute from './components/ProtectedRoute';
+import AdminRoute from './components/AdminRoute';
 import QuizCategories from './pages/QuizCategories';
 import SubCategories from './pages/SubCategories';
 import AllMegaTests from './pages/AllMegaTests';
@@ -116,9 +117,9 @@ const AppContent: React.FC = () => {
         </ProtectedRoute>
       } />
       <Route path="/admin/mega-tests" element={
-        <ProtectedRoute>
+        <AdminRoute>
           <MegaTestManager />
-        </ProtectedRoute>
+        </AdminRoute>
       } />
       <Route path="/mega-test/:megaTestId" element={
         <ProtectedRoute>

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../App';
+import { getCurrentAdmin } from '@/services/api/adminAuth';
+
+interface AdminRouteProps {
+  children: React.ReactNode;
+}
+
+const AdminRoute: React.FC<AdminRouteProps> = ({ children }) => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const check = async () => {
+      if (!user) {
+        setIsAdmin(false);
+        return;
+      }
+      try {
+        const admin = await getCurrentAdmin();
+        setIsAdmin(!!admin?.isAdmin);
+      } catch {
+        setIsAdmin(false);
+      }
+    };
+    if (!loading) {
+      check();
+    }
+  }, [user, loading]);
+
+  if (loading || isAdmin === null) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-pulse-subtle">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/admin-auth" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminRoute;


### PR DESCRIPTION
## Summary
- add `AdminRoute` component that checks admin privileges
- secure `/admin/mega-tests` with the new route

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686cf2cc8e90832b8bb0cb4afdc95964