### PR TITLE
Use backend for quiz data

### DIFF
--- a/backend/src/controllers/quizController.ts
+++ b/backend/src/controllers/quizController.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getQuizCategories = async (req: Request, res: Response) => {
+  try {
+    const snapshot = await db.collection('quiz-categories').get();
+    const categories = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(categories);
+  } catch (error) {
+    console.error('Error fetching quiz categories:', error);
+    res.status(500).json({ error: 'Failed to fetch quiz categories' });
+  }
+};
+
+export const getSubCategories = async (req: Request, res: Response) => {
+  try {
+    const { categoryId } = req.params;
+    const snapshot = await db
+      .collection('sub-categories')
+      .where('categoryId', '==', categoryId)
+      .get();
+    const subCategories = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(subCategories);
+  } catch (error) {
+    console.error('Error fetching sub categories:', error);
+    res.status(500).json({ error: 'Failed to fetch sub categories' });
+  }
+};
+
+export const getQuizzesByCategory = async (req: Request, res: Response) => {
+  try {
+    const { categoryId, subcategoryId } = req.query;
+    if (!categoryId || typeof categoryId !== 'string') {
+      return res.status(400).json({ error: 'categoryId is required' });
+    }
+    let queryRef: FirebaseFirestore.Query = db
+      .collection('quizzes')
+      .where('categoryId', '==', categoryId);
+    if (subcategoryId && typeof subcategoryId === 'string') {
+      queryRef = queryRef.where('subcategoryId', '==', subcategoryId);
+    }
+    const snapshot = await queryRef.get();
+    const quizzes = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(quizzes);
+  } catch (error) {
+    console.error('Error fetching quizzes:', error);
+    res.status(500).json({ error: 'Failed to fetch quizzes' });
+  }
+};
+
+export const getQuizById = async (req: Request, res: Response) => {
+  try {
+    const { quizId } = req.params;
+    const quizDoc = await db.collection('quizzes').doc(quizId).get();
+    if (!quizDoc.exists) {
+      return res.status(404).json({ error: 'Quiz not found' });
+    }
+    const questionsSnapshot = await db
+      .collection('quizzes')
+      .doc(quizId)
+      .collection('questions')
+      .get();
+    const questions = questionsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json({ id: quizDoc.id, ...quizDoc.data(), questions });
+  } catch (error) {
+    console.error('Error fetching quiz:', error);
+    res.status(500).json({ error: 'Failed to fetch quiz' });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import authRoutes from './authRoutes.js';
 import userRoutes from './userRoutes.js';
 import paymentRoutes from './paymentRoutes.js';
 import adminRoutes from './adminRoutes.js';
+import quizRoutes from './quizRoutes.js';
 
 const router = express.Router();
 
@@ -14,6 +15,9 @@ router.use('/users', userRoutes);
 
 // Payment routes
 router.use('/payments', paymentRoutes);
+
+// Quiz routes
+router.use('/quiz', quizRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);

--- a/backend/src/routes/quizRoutes.ts
+++ b/backend/src/routes/quizRoutes.ts
@@ -1,0 +1,17 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import {
+  getQuizCategories,
+  getSubCategories,
+  getQuizzesByCategory,
+  getQuizById
+} from '../controllers/quizController.js';
+
+const router = express.Router();
+
+router.get('/categories', authenticateUser, getQuizCategories);
+router.get('/categories/:categoryId/sub-categories', authenticateUser, getSubCategories);
+router.get('/quizzes', authenticateUser, getQuizzesByCategory);
+router.get('/quizzes/:quizId', authenticateUser, getQuizById);
+
+export default router;

--- a/src/pages/CategoryQuizzes.tsx
+++ b/src/pages/CategoryQuizzes.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Loader2, Search } from 'lucide-react';
-import { getQuizzesByCategory, getQuizCategories, getSubCategories } from '@/services/firebase/quiz';
+import { getQuizzesByCategory, getQuizCategories, getSubCategories } from '@/services/api/quiz';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 

--- a/src/pages/QuizCategories.tsx
+++ b/src/pages/QuizCategories.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Loader2, Search } from 'lucide-react';
-import { getQuizCategories } from '@/services/firebase/quiz';
+import { getQuizCategories } from '@/services/api/quiz';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/src/pages/SubCategories.tsx
+++ b/src/pages/SubCategories.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Loader2, Search } from 'lucide-react';
-import { getSubCategories, getQuizCategories } from '@/services/firebase/quiz';
+import { getSubCategories, getQuizCategories } from '@/services/api/quiz';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 

--- a/src/services/api/quiz.ts
+++ b/src/services/api/quiz.ts
@@ -1,0 +1,70 @@
+import axios from 'axios';
+import { getAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface QuizCategory {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface SubCategory {
+  id: string;
+  categoryId: string;
+  title: string;
+  description: string;
+}
+
+export interface Quiz {
+  id: string;
+  title: string;
+  description: string;
+  categoryId: string;
+  subcategoryId: string;
+}
+
+export interface QuizQuestion {
+  id: string;
+  text: string;
+  options: any[];
+  correctAnswer: string;
+}
+
+export const getQuizCategories = async (): Promise<QuizCategory[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/quiz/categories`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getSubCategories = async (categoryId: string): Promise<SubCategory[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/quiz/categories/${categoryId}/sub-categories`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data;
+};
+
+export const getQuizzesByCategory = async (
+  categoryId: string,
+  subcategoryId?: string
+): Promise<Quiz[]> => {
+  const token = await getAuthToken();
+  const params = new URLSearchParams({ categoryId });
+  if (subcategoryId) params.append('subcategoryId', subcategoryId);
+  const res = await axios.get(`${API_URL}/api/quiz/quizzes?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getQuizById = async (quizId: string): Promise<Quiz & { questions: QuizQuestion[] }> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/quiz/quizzes/${quizId}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add secure backend routes for quiz data
- migrate quiz pages to use backend API

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm --prefix backend run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686d34152eb8832bbc17484000cbbfba