### PR TITLE
Secure megatest feature via backend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import authRoutes from './routes/authRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import paymentRoutes from './routes/paymentRoutes.js';
 import adminRoutes from './routes/adminRoutes.js';
+import megaTestRoutes from './routes/megaTestRoutes.js';
 
 import { authLimiter, apiLimiter, adminLimiter } from './middleware/rateLimit.js';
 import { securityHeaders } from './middleware/securityHeaders.js';
@@ -60,6 +61,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/payments', paymentRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/mega-tests', megaTestRoutes);
 
 // --- Health Check Endpoint ---
 app.get('/health', (req, res) => {

--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -1,0 +1,71 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getMegaTests = async (req: Request, res: Response) => {
+  try {
+    const snapshot = await db
+      .collection('mega-tests')
+      .orderBy('createdAt', 'desc')
+      .get();
+    const megaTests = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(megaTests);
+  } catch (error) {
+    console.error('Error fetching mega tests:', error);
+    res.status(500).json({ error: 'Failed to fetch mega tests' });
+  }
+};
+
+export const registerForMegaTest = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const { uid, email } = req.user!;
+    const { username } = req.body;
+
+    const megaTestDoc = await db.collection('mega-tests').doc(megaTestId).get();
+    if (!megaTestDoc.exists) {
+      return res.status(404).json({ error: 'Mega test not found' });
+    }
+
+    const megaTest = megaTestDoc.data() as any;
+    const entryFee = megaTest.entryFee || 0;
+
+    const balanceRef = db.collection('balance').doc(uid);
+    const balanceDoc = await balanceRef.get();
+    if (!balanceDoc.exists) {
+      return res.status(400).json({ error: 'User balance not found' });
+    }
+
+    const currentBalance = balanceDoc.data()?.amount || 0;
+    if (currentBalance < entryFee) {
+      return res.status(400).json({ error: 'Insufficient balance' });
+    }
+
+    const batch = db.batch();
+    if (entryFee > 0) {
+      batch.update(balanceRef, {
+        amount: currentBalance - entryFee,
+        lastUpdated: new Date().toISOString()
+      });
+    }
+
+    const participantRef = db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('participants')
+      .doc(uid);
+
+    batch.set(participantRef, {
+      userId: uid,
+      username,
+      email,
+      registeredAt: new Date(),
+      entryFeePaid: entryFee
+    });
+
+    await batch.commit();
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error registering for mega test:', error);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import userRoutes from './userRoutes.js';
 import paymentRoutes from './paymentRoutes.js';
 import adminRoutes from './adminRoutes.js';
 import quizRoutes from './quizRoutes.js';
+import megaTestRoutes from './megaTestRoutes.js';
 
 const router = express.Router();
 
@@ -18,6 +19,7 @@ router.use('/payments', paymentRoutes);
 
 // Quiz routes
 router.use('/quiz', quizRoutes);
+router.use('/mega-tests', megaTestRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);

--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import { getMegaTests, registerForMegaTest } from '../controllers/megaTestController.js';
+
+const router = express.Router();
+
+router.get('/', authenticateUser, getMegaTests);
+router.post('/:megaTestId/register', authenticateUser, registerForMegaTest);
+
+export default router;

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import { getAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface MegaTest {
+  id: string;
+  title: string;
+  description: string;
+  [key: string]: any;
+}
+
+export const getMegaTests = async (): Promise<MegaTest[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const registerForMegaTest = async (
+  megaTestId: string,
+  username: string
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/register`,
+    { username },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};


### PR DESCRIPTION
## Summary
- add backend controller and routes for megatest operations
- expose new backend endpoints in `app.ts` and router index
- create frontend API service for megatest
- refactor firebase service to call new backend for megatest list and registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686d36a06d6c832ba202bee173a54fdf