### PR TITLE
Add backend endpoints for question papers

### DIFF
--- a/backend/src/controllers/questionPaperController.ts
+++ b/backend/src/controllers/questionPaperController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getQuestionPaperCategories = async (_req: Request, res: Response) => {
+  try {
+    const snapshot = await db.collection('questionPaperCategories').get();
+    const categories = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(categories);
+  } catch (error) {
+    console.error('Error fetching question paper categories:', error);
+    res.status(500).json({ error: 'Failed to fetch question paper categories' });
+  }
+};
+
+export const getQuestionPapersByCategory = async (req: Request, res: Response) => {
+  try {
+    const { categoryId } = req.params;
+    const snapshot = await db
+      .collection('questionPapers')
+      .where('categoryId', '==', categoryId)
+      .get();
+    const papers = snapshot.docs
+      .map(doc => ({ id: doc.id, ...doc.data() }))
+      .sort((a, b) => {
+        const aTime = (a.createdAt as any)?.toMillis?.() ?? 0;
+        const bTime = (b.createdAt as any)?.toMillis?.() ?? 0;
+        return bTime - aTime;
+      });
+    res.json(papers);
+  } catch (error) {
+    console.error('Error fetching question papers:', error);
+    res.status(500).json({ error: 'Failed to fetch question papers' });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import userRoutes from './userRoutes.js';
 import paymentRoutes from './paymentRoutes.js';
 import adminRoutes from './adminRoutes.js';
 import quizRoutes from './quizRoutes.js';
+import questionPaperRoutes from './questionPaperRoutes.js';
 
 const router = express.Router();
 
@@ -18,6 +19,9 @@ router.use('/payments', paymentRoutes);
 
 // Quiz routes
 router.use('/quiz', quizRoutes);
+
+// Question paper routes
+router.use('/question-papers', questionPaperRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);

--- a/backend/src/routes/questionPaperRoutes.ts
+++ b/backend/src/routes/questionPaperRoutes.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import {
+  getQuestionPaperCategories,
+  getQuestionPapersByCategory,
+} from '../controllers/questionPaperController.js';
+
+const router = express.Router();
+
+router.use(authenticateUser);
+
+router.get('/categories', getQuestionPaperCategories);
+router.get('/categories/:categoryId/papers', getQuestionPapersByCategory);
+
+export default router;

--- a/src/pages/QuestionPaperCategory.tsx
+++ b/src/pages/QuestionPaperCategory.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { getQuestionPapersByCategory, getQuestionPaperCategories } from '../services/firebase/questionPapers';
-import type { QuestionPaper, QuestionPaperCategory } from '../services/firebase/questionPapers';
+import { getQuestionPapersByCategory, getQuestionPaperCategories } from '../services/api/questionPapers';
+import type { QuestionPaper, QuestionPaperCategory } from '../services/api/questionPapers';
 import { ArrowLeft, Download, Calendar, FileText, Clock } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '../components/ui/card';

--- a/src/pages/QuestionPapers.tsx
+++ b/src/pages/QuestionPapers.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getQuestionPaperCategories } from '../services/firebase/questionPapers';
-import type { QuestionPaperCategory } from '../services/firebase/questionPapers';
+import { getQuestionPaperCategories } from '../services/api/questionPapers';
+import type { QuestionPaperCategory } from '../services/api/questionPapers';
 import { ArrowLeft, BookOpen, Download, Users, Clock, Star, TrendingUp } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '../components/ui/card';

--- a/src/services/api/questionPapers.ts
+++ b/src/services/api/questionPapers.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import { getAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface QuestionPaperCategory {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface QuestionPaper {
+  id: string;
+  categoryId: string;
+  title: string;
+  description: string;
+  year: number;
+  fileUrl: string;
+  fileSize: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const getQuestionPaperCategories = async (): Promise<QuestionPaperCategory[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/question-papers/categories`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getQuestionPapersByCategory = async (categoryId: string): Promise<QuestionPaper[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/question-papers/categories/${categoryId}/papers`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add express controller & routes for question papers
- expose new `/api/question-papers` endpoints
- call new API from question paper pages

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d405fd6f8832bb1e643ccca654c41