### PR TITLE
Add backend prize claim API and update frontend

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -1,0 +1,103 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const submitPrizeClaim = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const { name, mobile, address, prize, rank, ipAddress, deviceId } = req.body;
+    const userId = req.user?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const claimRef = db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('prize-claims')
+      .doc(userId);
+
+    await claimRef.set({
+      name,
+      mobile,
+      address,
+      prize,
+      rank,
+      userId,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      ipAddress: ipAddress || req.ip,
+      deviceId: deviceId || null,
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error submitting prize claim:', error);
+    res.status(500).json({ error: 'Failed to submit prize claim' });
+  }
+};
+
+export const getUserPrizes = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+
+    const megaTestsSnap = await db.collection('mega-tests').get();
+    const result: any[] = [];
+    const now = Date.now();
+
+    for (const docSnap of megaTestsSnap.docs) {
+      const megaTestId = docSnap.id;
+      const megaTest = docSnap.data();
+      const resultTime = megaTest.resultTime?.toMillis?.() ?? 0;
+      if (resultTime > now) continue;
+
+      const leaderboardSnap = await db
+        .collection('mega-tests')
+        .doc(megaTestId)
+        .collection('leaderboard')
+        .where('userId', '==', userId)
+        .get();
+
+      if (leaderboardSnap.empty) continue;
+
+      const userEntry = leaderboardSnap.docs[0].data();
+      const rank = userEntry.rank;
+
+      const prizesSnap = await db
+        .collection('mega-tests')
+        .doc(megaTestId)
+        .collection('prizes')
+        .get();
+
+      const prize = prizesSnap.docs
+        .map(p => p.data())
+        .find((p: any) => p.rank === rank);
+
+      if (!prize) continue;
+
+      const claimSnap = await db
+        .collection('mega-tests')
+        .doc(megaTestId)
+        .collection('prize-claims')
+        .doc(userId)
+        .get();
+
+      let claimStatus = 'unclaimed';
+      if (claimSnap.exists) {
+        claimStatus = (claimSnap.data() as any).status || 'claimed';
+      }
+
+      result.push({
+        megaTestId,
+        megaTestTitle: megaTest.title,
+        prize: prize.prize,
+        rank: prize.rank,
+        claimStatus,
+      });
+    }
+
+    res.json(result);
+  } catch (error) {
+    console.error('Error fetching prizes:', error);
+    res.status(500).json({ error: 'Failed to fetch prizes' });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -5,6 +5,7 @@ import paymentRoutes from './paymentRoutes.js';
 import adminRoutes from './adminRoutes.js';
 import quizRoutes from './quizRoutes.js';
 import questionPaperRoutes from './questionPaperRoutes.js';
+import megaTestRoutes from './megaTestRoutes.js';
 
 const router = express.Router();
 
@@ -22,6 +23,9 @@ router.use('/quiz', quizRoutes);
 
 // Question paper routes
 router.use('/question-papers', questionPaperRoutes);
+
+// Mega test routes
+router.use('/mega-tests', megaTestRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);

--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import { submitPrizeClaim } from '../controllers/megaTestController.js';
+
+const router = express.Router();
+
+router.post('/:megaTestId/prize-claims', authenticateUser, submitPrizeClaim);
+
+export default router;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { getUserProfile, getUserBalance, updateUserBalance, captureUserIP } from '../controllers/userController.js';
+import { getUserPrizes } from '../controllers/megaTestController.js';
 import { authenticateUser } from '../middleware/auth.js';
 
 const router = express.Router();
@@ -11,5 +12,6 @@ router.get('/profile/:userId', getUserProfile);
 router.get('/balance/:userId', getUserBalance);
 router.put('/balance', updateUserBalance);
 router.post('/capture-ip', captureUserIP);
+router.get('/prizes/:userId', getUserPrizes);
 
 export default router;

--- a/src/components/PrizeClaimForm.tsx
+++ b/src/components/PrizeClaimForm.tsx
@@ -6,9 +6,9 @@ import { SanitizedInput } from "@/components/ui/sanitized-input";
 import { SanitizedTextarea } from "@/components/ui/sanitized-textarea";
 import { Label } from "@/components/ui/label";
 import { toast } from 'sonner';
-import { doc, setDoc } from 'firebase/firestore';
-import { db, auth } from '../services/firebase/config';
+import { auth } from '../services/firebase/config';
 import { useAuthState } from 'react-firebase-hooks/auth';
+import { submitPrizeClaim } from '../services/api/megaTest';
 import { getClientIP } from '@/utils/ipDetection';
 import { getDeviceId } from '@/utils/deviceId';
 
@@ -42,16 +42,11 @@ const PrizeClaimForm = ({ megaTestId, prize, rank, onSuccess }: PrizeClaimFormPr
       const ipAddress = await getClientIP();
       const deviceId = getDeviceId();
 
-      // Create a new document in the prize-claims collection
-      const claimRef = doc(db, 'mega-tests', megaTestId, 'prize-claims', user.uid);
-      await setDoc(claimRef, {
+      await submitPrizeClaim(megaTestId, {
         ...formData,
         prize,
         rank,
-        userId: user.uid,
-        status: 'pending',
-        createdAt: new Date(),
-        ipAddress,
+        ipAddress: ipAddress || undefined,
         deviceId,
       });
 

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { getAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface UserPrize {
+  megaTestId: string;
+  megaTestTitle: string;
+  prize: string;
+  rank: number;
+  claimStatus: 'unclaimed' | 'pending' | 'approved' | 'rejected' | 'claimed';
+}
+
+export const submitPrizeClaim = async (
+  megaTestId: string,
+  data: { name: string; mobile: string; address: string; prize: string; rank: number; ipAddress?: string; deviceId?: string }
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(`${API_URL}/api/mega-tests/${megaTestId}/prize-claims`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+};
+
+export const getUserPrizes = async (userId: string): Promise<UserPrize[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/users/${userId}/prizes`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add new prize claim controller and route in backend
- expose /mega-tests route in router and prizes endpoint in userRoutes
- create frontend API wrapper for mega test operations
- update PrizeClaimForm and UserPrizes components to use new backend APIs

## Testing
- `npm install`
- `npm run lint` *(fails: many lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_686d42e19918832b9460c5092a7aaf84