### PR TITLE
Switch leaderboard to backend API

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -101,3 +101,22 @@ export const getUserPrizes = async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Failed to fetch prizes' });
   }
 };
+
+export const getMegaTestLeaderboard = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+
+    const leaderboardSnap = await db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('leaderboard')
+      .orderBy('score', 'desc')
+      .get();
+
+    const entries = leaderboardSnap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(entries);
+  } catch (error) {
+    console.error('Error fetching leaderboard:', error);
+    res.status(500).json({ error: 'Failed to fetch leaderboard' });
+  }
+};

--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import { authenticateUser } from '../middleware/auth.js';
-import { submitPrizeClaim } from '../controllers/megaTestController.js';
+import { submitPrizeClaim, getMegaTestLeaderboard } from '../controllers/megaTestController.js';
 
 const router = express.Router();
 
 router.post('/:megaTestId/prize-claims', authenticateUser, submitPrizeClaim);
+router.get('/:megaTestId/leaderboard', authenticateUser, getMegaTestLeaderboard);
 
 export default router;

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -28,3 +28,22 @@ export const getUserPrizes = async (userId: string): Promise<UserPrize[]> => {
   });
   return res.data;
 };
+
+export interface MegaTestLeaderboardEntry {
+  userId: string;
+  score: number;
+  rank: number;
+  submittedAt: string;
+  completionTime: number;
+}
+
+export const getMegaTestLeaderboard = async (
+  megaTestId: string
+): Promise<MegaTestLeaderboardEntry[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/mega-tests/${megaTestId}/leaderboard`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data;
+};

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -1,5 +1,6 @@
 import { collection, doc, getDocs, query, setDoc, where, addDoc, getDoc, serverTimestamp, Timestamp, updateDoc, deleteDoc, arrayUnion, writeBatch } from 'firebase/firestore';
 import { db } from './config';
+import { getMegaTestLeaderboard as fetchLeaderboard, MegaTestLeaderboardEntry } from '../api/megaTest';
 import { updateUserBalance } from './balance';
 import { getClientIP } from '@/utils/ipDetection';
 import { getDeviceId } from '@/utils/deviceId';
@@ -704,11 +705,7 @@ export const submitMegaTestResult = async (
 
 export const getMegaTestLeaderboard = async (megaTestId: string): Promise<MegaTestLeaderboardEntry[]> => {
   try {
-    const leaderboardRef = collection(db, 'mega-tests', megaTestId, 'leaderboard');
-    const snapshot = await getDocs(leaderboardRef);
-    return snapshot.docs
-      .map(doc => doc.data() as MegaTestLeaderboardEntry)
-      .sort((a, b) => a.rank - b.rank);
+    return await fetchLeaderboard(megaTestId);
   } catch (error) {
     console.error('Error fetching leaderboard:', error);
     return [];


### PR DESCRIPTION
## Summary
- add new controller and route for getting leaderboard data
- expose leaderboard API in frontend service
- update Firebase quiz utilities to call backend
- refactor MegaTestLeaderboard component to use backend API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' / many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d4b387ec8832b92478a25d1998693