### PR TITLE
Move mega-test logic to backend

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -120,3 +120,185 @@ export const getMegaTestLeaderboard = async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Failed to fetch leaderboard' });
   }
 };
+export const getMegaTests = async (req: Request, res: Response) => {
+  try {
+    const snapshot = await db.collection('mega-tests').get();
+    const megaTests = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    megaTests.sort((a, b) => {
+      const aTime = a.createdAt?.toMillis?.() || 0;
+      const bTime = b.createdAt?.toMillis?.() || 0;
+      return bTime - aTime;
+    });
+    res.json(megaTests);
+  } catch (error) {
+    console.error('Error fetching mega tests:', error);
+    res.status(500).json({ error: 'Failed to fetch mega tests' });
+  }
+};
+
+export const getMegaTestById = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const megaTestRef = db.collection('mega-tests').doc(megaTestId);
+    const [megaTestDoc, questionsSnap] = await Promise.all([
+      megaTestRef.get(),
+      megaTestRef.collection('questions').get()
+    ]);
+    if (!megaTestDoc.exists) {
+      return res.status(404).json({ error: 'Mega test not found' });
+    }
+    const questions = questionsSnap.docs.map(q => ({ id: q.id, ...q.data() }));
+    res.json({ megaTest: { id: megaTestDoc.id, ...megaTestDoc.data() }, questions });
+  } catch (error) {
+    console.error('Error fetching mega test:', error);
+    res.status(500).json({ error: 'Failed to fetch mega test' });
+  }
+};
+
+export const getMegaTestPrizes = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const prizesSnap = await db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('prizes')
+      .get();
+    const prizes = prizesSnap.docs
+      .map(p => p.data())
+      .sort((a, b) => a.rank - b.rank);
+    res.json(prizes);
+  } catch (error) {
+    console.error('Error fetching mega test prizes:', error);
+    res.status(500).json({ error: 'Failed to fetch prizes' });
+  }
+};
+
+export const registerForMegaTest = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const { username, email, ipAddress, deviceId } = req.body;
+    const userId = req.user?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const megaTestRef = db.collection('mega-tests').doc(megaTestId);
+    const megaTestDoc = await megaTestRef.get();
+    if (!megaTestDoc.exists) {
+      return res.status(404).json({ error: 'Mega test not found' });
+    }
+    const entryFee = megaTestDoc.data()?.entryFee || 0;
+    const balanceRef = db.collection('balance').doc(userId);
+    const balanceDoc = await balanceRef.get();
+    if (!balanceDoc.exists) {
+      return res.status(400).json({ error: 'User balance not found' });
+    }
+    const currentBalance = balanceDoc.data()?.amount || 0;
+    if (currentBalance < entryFee) {
+      return res.status(400).json({ error: `Insufficient balance. Required: ₹${entryFee}, Available: ₹${currentBalance}` });
+    }
+    await db.runTransaction(async transaction => {
+      if (entryFee > 0) {
+        transaction.update(balanceRef, {
+          amount: currentBalance - entryFee,
+          lastUpdated: new Date().toISOString()
+        });
+      }
+      const participantRef = megaTestRef.collection('participants').doc(userId);
+      transaction.set(participantRef, {
+        userId,
+        username,
+        email,
+        registeredAt: new Date().toISOString(),
+        entryFeePaid: entryFee,
+        ipAddress: ipAddress || req.ip,
+        lastSeenIP: ipAddress || req.ip,
+        deviceId: deviceId || null
+      });
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error registering for mega test:', error);
+    res.status(500).json({ error: 'Failed to register for mega test' });
+  }
+};
+
+export const isUserRegistered = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const userId = req.user?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const participantDoc = await db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('participants')
+      .doc(userId)
+      .get();
+    res.json({ registered: participantDoc.exists });
+  } catch (error) {
+    console.error('Error checking registration:', error);
+    res.status(500).json({ error: 'Failed to check registration' });
+  }
+};
+
+export const hasUserSubmittedMegaTest = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const userId = req.user?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const submissionDoc = await db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('leaderboard')
+      .doc(userId)
+      .get();
+    res.json({ submitted: submissionDoc.exists });
+  } catch (error) {
+    console.error('Error checking submission status:', error);
+    res.status(500).json({ error: 'Failed to check submission status' });
+  }
+};
+
+export const submitMegaTestResult = async (req: Request, res: Response) => {
+  try {
+    const { megaTestId } = req.params;
+    const { score, completionTime } = req.body;
+    const userId = req.user?.uid;
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const leaderboardRef = db
+      .collection('mega-tests')
+      .doc(megaTestId)
+      .collection('leaderboard');
+    const leaderboardSnap = await leaderboardRef.get();
+    const leaderboard = leaderboardSnap.docs.map(doc => doc.data() as any);
+    const newEntry = {
+      userId,
+      score,
+      rank: 0,
+      submittedAt: new Date().toISOString(),
+      completionTime
+    };
+    leaderboard.push(newEntry);
+    leaderboard.sort((a, b) => {
+      if (a.score !== b.score) {
+        return b.score - a.score;
+      }
+      return a.completionTime - b.completionTime;
+    });
+    const batch = db.batch();
+    leaderboard.forEach((entry, index) => {
+      const ref = leaderboardRef.doc(entry.userId);
+      batch.set(ref, { ...entry, rank: index + 1 });
+    });
+    await batch.commit();
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error submitting mega test result:', error);
+    res.status(500).json({ error: 'Failed to submit mega test result' });
+  }
+};

--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -1,10 +1,28 @@
 import express from 'express';
 import { authenticateUser } from '../middleware/auth.js';
-import { submitPrizeClaim, getMegaTestLeaderboard } from '../controllers/megaTestController.js';
+import {
+  submitPrizeClaim,
+  getMegaTestLeaderboard,
+  getMegaTests,
+  getMegaTestById,
+  getMegaTestPrizes,
+  registerForMegaTest,
+  isUserRegistered,
+  hasUserSubmittedMegaTest,
+  submitMegaTestResult
+} from '../controllers/megaTestController.js';
 
 const router = express.Router();
 
 router.post('/:megaTestId/prize-claims', authenticateUser, submitPrizeClaim);
 router.get('/:megaTestId/leaderboard', authenticateUser, getMegaTestLeaderboard);
+
+router.get('/', authenticateUser, getMegaTests);
+router.get('/:megaTestId', authenticateUser, getMegaTestById);
+router.get('/:megaTestId/prizes', authenticateUser, getMegaTestPrizes);
+router.post('/:megaTestId/register', authenticateUser, registerForMegaTest);
+router.get('/:megaTestId/is-registered', authenticateUser, isUserRegistered);
+router.get('/:megaTestId/has-submitted', authenticateUser, hasUserSubmittedMegaTest);
+router.post('/:megaTestId/submit', authenticateUser, submitMegaTestResult);
 
 export default router;

--- a/src/components/MegaTestLeaderboard.tsx
+++ b/src/components/MegaTestLeaderboard.tsx
@@ -5,7 +5,7 @@ import { Trophy, Medal, User, Search, ChevronLeft, ChevronRight } from 'lucide-r
 import { MegaTestLeaderboardEntry } from '../services/api/megaTest';
 import { getMegaTestLeaderboard } from '../services/api/megaTest';
 import { useQuery } from '@tanstack/react-query';
-import { getUserById } from '../services/firebase/auth';
+import { getUserProfile } from '../services/api/user';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from '../App';
@@ -29,11 +29,11 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
 
       const entriesWithUserDetails = await Promise.all(
         snapshot.map(async (entry) => {
-          const user = await getUserById(entry.userId);
+          const user = await getUserProfile(entry.userId);
           return {
             ...entry,
-            userName: user?.username || user?.displayName || 'Anonymous User',
-            userPhotoURL: user?.photoURL,
+            userName: user?.username || 'Anonymous User',
+            userPhotoURL: undefined,
           };
         })
       );

--- a/src/pages/AllMegaTests.tsx
+++ b/src/pages/AllMegaTests.tsx
@@ -3,13 +3,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Clock, ListChecks, CreditCard, Trophy, Loader2 } from 'lucide-react';
-import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest } from '@/services/firebase/quiz';
+import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest, registerForMegaTest } from '@/services/api/megaTest';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { useAuth } from '../App';
 import MegaTestLeaderboard from '../components/MegaTestLeaderboard';
 import MegaTestPrizes from '../components/MegaTestPrizes';
-import { registerForMegaTest } from '@/services/firebase/quiz';
 import { useState } from 'react';
 import RegistrationCountdown from '../components/RegistrationCountdown';
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getQuizCategories } from '../services/api/quiz';
-import { getMegaTests, registerForMegaTest, isUserRegistered, hasUserSubmittedMegaTest, MegaTest } from '../services/firebase/quiz';
+import { getMegaTests, registerForMegaTest, isUserRegistered, hasUserSubmittedMegaTest, MegaTest } from '../services/api/megaTest';
 import { AuthContext } from '../App';
 import { Card } from "@/components/ui/card";
 import { CardContent } from "@/components/ui/card";

--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Loader2, ChevronRight, ChevronLeft, Clock, CreditCard, Trophy } from 'lucide-react';
-import { getMegaTestById, submitMegaTestResult, MegaTestQuestion, hasUserSubmittedMegaTest } from '@/services/firebase/quiz';
+import { getMegaTestById, submitMegaTestResult, MegaTestQuestion, hasUserSubmittedMegaTest } from '@/services/api/megaTest';
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { toast } from 'sonner';

--- a/src/pages/MegaTestPrizes.tsx
+++ b/src/pages/MegaTestPrizes.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Trophy } from 'lucide-react';
-import { getMegaTestById, getMegaTestPrizes } from '@/services/firebase/quiz';
+import { getMegaTestById, getMegaTestPrizes } from '@/services/api/megaTest';
 
 const MegaTestPrizesPage = () => {
   const { megaTestId } = useParams();

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -47,3 +47,113 @@ export const getMegaTestLeaderboard = async (
   );
   return res.data;
 };
+
+export interface MegaTest {
+  id: string;
+  title: string;
+  description: string;
+  registrationStartTime: any;
+  registrationEndTime: any;
+  testStartTime: any;
+  testEndTime: any;
+  resultTime: any;
+  totalQuestions: number;
+  createdAt: any;
+  updatedAt: any;
+  status: 'upcoming' | 'registration' | 'ongoing' | 'completed';
+  entryFee: number;
+  timeLimit: number;
+}
+
+export interface MegaTestQuestion {
+  id: string;
+  text: string;
+  options: any[];
+  correctAnswer: string;
+}
+
+export interface MegaTestPrize {
+  rank: number;
+  prize: string;
+}
+
+export const getMegaTests = async (): Promise<MegaTest[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getMegaTestById = async (
+  megaTestId: string
+): Promise<{ megaTest: MegaTest; questions: MegaTestQuestion[] }> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests/${megaTestId}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getMegaTestPrizes = async (
+  megaTestId: string
+): Promise<MegaTestPrize[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests/${megaTestId}/prizes`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const registerForMegaTest = async (
+  megaTestId: string,
+  userId: string,
+  username: string,
+  email: string,
+  ipAddress?: string,
+  deviceId?: string
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/register`,
+    { userId, username, email, ipAddress, deviceId },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};
+
+export const isUserRegistered = async (
+  megaTestId: string,
+  userId: string
+): Promise<boolean> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/mega-tests/${megaTestId}/is-registered`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data.registered;
+};
+
+export const hasUserSubmittedMegaTest = async (
+  megaTestId: string,
+  userId: string
+): Promise<boolean> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/mega-tests/${megaTestId}/has-submitted`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data.submitted;
+};
+
+export const submitMegaTestResult = async (
+  megaTestId: string,
+  score: number,
+  completionTime: number
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/submit`,
+    { score, completionTime },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};


### PR DESCRIPTION
## Summary
- implement backend API for mega tests
- expose new mega-test endpoints
- use backend API instead of Firestore in mega-test pages
- fetch user profiles from backend in leaderboard component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `cd backend && npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d50d34680832b9eace63277da3a8f