### PR TITLE
Update frontend to use backend APIs

### DIFF
--- a/backend/src/controllers/paidContentController.ts
+++ b/backend/src/controllers/paidContentController.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getPaidContents = async (_req: Request, res: Response) => {
+  try {
+    const snapshot = await db.collection('paidContents').get();
+    const contents = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(contents);
+  } catch (error) {
+    console.error('Error fetching paid contents:', error);
+    res.status(500).json({ error: 'Failed to fetch paid contents' });
+  }
+};
+
+export const getPurchasedContent = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    const userDoc = await db.collection('users').doc(userId).get();
+    const purchasedIds = userDoc.exists ? userDoc.data()?.purchases || [] : [];
+    if (purchasedIds.length === 0) {
+      return res.json([]);
+    }
+    const contentsSnap = await db.collection('paidContents').get();
+    const contents = contentsSnap.docs
+      .map(doc => ({ id: doc.id, ...doc.data() }))
+      .filter(content => purchasedIds.includes(content.id));
+    res.json(contents);
+  } catch (error) {
+    console.error('Error fetching purchased content:', error);
+    res.status(500).json({ error: 'Failed to fetch purchased content' });
+  }
+};
+
+export const purchaseContent = async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    const { contentId } = req.body;
+    if (!contentId) {
+      return res.status(400).json({ error: 'contentId is required' });
+    }
+
+    const userRef = db.collection('users').doc(userId);
+    const balanceRef = db.collection('balance').doc(userId);
+    const contentDoc = await db.collection('paidContents').doc(contentId).get();
+    if (!contentDoc.exists) {
+      return res.status(404).json({ error: 'Content not found' });
+    }
+    const content = contentDoc.data() as any;
+
+    await db.runTransaction(async tx => {
+      const [userDoc, balanceDoc] = await Promise.all([
+        tx.get(userRef),
+        tx.get(balanceRef)
+      ]);
+      const purchases: string[] = userDoc.exists ? userDoc.data()?.purchases || [] : [];
+      if (purchases.includes(contentId)) {
+        return;
+      }
+      const currentBalance = balanceDoc.exists ? balanceDoc.data()?.amount || 0 : 0;
+      if (currentBalance < content.price) {
+        throw new Error('Insufficient balance');
+      }
+      tx.update(balanceRef, {
+        amount: currentBalance - content.price,
+        lastUpdated: new Date().toISOString()
+      });
+      tx.set(userRef, { purchases: [...purchases, contentId] }, { merge: true });
+    });
+
+    res.json({ success: true });
+  } catch (error: any) {
+    console.error('Error processing purchase:', error);
+    res.status(500).json({ error: error.message || 'Failed to process purchase' });
+  }
+};

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import quizRoutes from './quizRoutes.js';
 import questionPaperRoutes from './questionPaperRoutes.js';
 import megaTestRoutes from './megaTestRoutes.js';
 import contentRoutes from './contentRoutes.js';
+import paidContentRoutes from './paidContentRoutes.js';
 
 const router = express.Router();
 
@@ -30,6 +31,7 @@ router.use('/mega-tests', megaTestRoutes);
 
 // Public content routes
 router.use('/content', contentRoutes);
+router.use('/paid-contents', paidContentRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);
@@ -37,5 +39,4 @@ router.use('/admin', adminRoutes);
 // Health check route
 router.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
-});
-export default router; 
+});export default router; 

--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -1,10 +1,22 @@
 import express from 'express';
 import { authenticateUser } from '../middleware/auth.js';
-import { submitPrizeClaim, getMegaTestLeaderboard } from '../controllers/megaTestController.js';
+import {
+  submitPrizeClaim,
+  getMegaTestLeaderboard,
+  getMegaTests,
+  registerForMegaTest,
+  isUserRegistered,
+  hasUserSubmittedMegaTest
+} from '../controllers/megaTestController.js';
 
 const router = express.Router();
 
-router.post('/:megaTestId/prize-claims', authenticateUser, submitPrizeClaim);
-router.get('/:megaTestId/leaderboard', authenticateUser, getMegaTestLeaderboard);
+router.use(authenticateUser);
+router.get('/', getMegaTests);
+router.post('/:megaTestId/register', registerForMegaTest);
+router.get('/:megaTestId/registration-status/:userId', isUserRegistered);
+router.get('/:megaTestId/submission-status/:userId', hasUserSubmittedMegaTest);
+router.post('/:megaTestId/prize-claims', submitPrizeClaim);
+router.get('/:megaTestId/leaderboard', getMegaTestLeaderboard);
 
 export default router;

--- a/backend/src/routes/paidContentRoutes.ts
+++ b/backend/src/routes/paidContentRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import { getPaidContents } from '../controllers/paidContentController.js';
+
+const router = express.Router();
+router.use(authenticateUser);
+router.get('/', getPaidContents);
+export default router;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { getUserProfile, getUserBalance, updateUserBalance, captureUserIP } from '../controllers/userController.js';
 import { getUserPrizes } from '../controllers/megaTestController.js';
+import { getPurchasedContent, purchaseContent } from '../controllers/paidContentController.js';
 import { authenticateUser } from '../middleware/auth.js';
 
 const router = express.Router();
@@ -13,5 +14,6 @@ router.get('/balance/:userId', getUserBalance);
 router.put('/balance', updateUserBalance);
 router.post('/capture-ip', captureUserIP);
 router.get('/prizes/:userId', getUserPrizes);
-
+router.get('/purchased-content/:userId', getPurchasedContent);
+router.post('/purchased-content/:userId', purchaseContent);
 export default router;

--- a/src/pages/AllMegaTests.tsx
+++ b/src/pages/AllMegaTests.tsx
@@ -3,13 +3,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Clock, ListChecks, CreditCard, Trophy, Loader2 } from 'lucide-react';
-import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest } from '@/services/firebase/quiz';
+import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest, registerForMegaTest } from '@/services/api/megaTest';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { useAuth } from '../App';
 import MegaTestLeaderboard from '../components/MegaTestLeaderboard';
 import MegaTestPrizes from '../components/MegaTestPrizes';
-import { registerForMegaTest } from '@/services/firebase/quiz';
 import { useState } from 'react';
 import RegistrationCountdown from '../components/RegistrationCountdown';
 

--- a/src/pages/PurchasedContent.tsx
+++ b/src/pages/PurchasedContent.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
-import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
-import { db } from '../services/firebase/config';
+import { getPurchasedContents } from '../services/api/paidContent';
 import { useAuth } from '../App';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -36,36 +35,8 @@ export default function PurchasedContentPage() { // Renamed component
     setLoading(true);
 
     try {
-      const userDocRef = doc(db, 'users', user.uid);
-      const userDocSnap = await getDoc(userDocRef);
-      const userData = userDocSnap.data();
-      const purchasedIds = userData?.purchases || [];
-
-      if (purchasedIds.length === 0) {
-        setContents([]);
-        setLoading(false);
-        return;
-      }
-
-      const contentsRef = collection(db, 'paidContents');
-      const snapshot = await getDocs(contentsRef);
-      
-      const purchasedContentsData = snapshot.docs
-        .map(docSnapshot => ({
-          id: docSnapshot.id,
-          ...docSnapshot.data()
-        }))
-        .filter(content => purchasedIds.includes(content.id)) as PurchasedContent[];
-      
-      // TODO: Enrich with purchase date if stored. For now, it's optional.
-      // Example: if you store purchase dates in user document:
-      // const purchasedItemsWithDate = purchasedContentsData.map(item => {
-      //   const purchaseRecord = userData?.purchaseHistory?.find(p => p.contentId === item.id);
-      //   return { ...item, purchaseDate: purchaseRecord?.date.toDate().toISOString() };
-      // });
-      // setContents(purchasedItemsWithDate);
-
-      setContents(purchasedContentsData);
+      const data = await getPurchasedContents(user.uid);
+      setContents(data);
     } catch (error) {
       console.error('Error fetching purchased contents:', error);
       toast.error('Failed to load purchased contents');

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -37,6 +37,23 @@ export interface MegaTestLeaderboardEntry {
   completionTime: number;
 }
 
+export interface MegaTest {
+  id: string;
+  title: string;
+  description: string;
+  registrationStartTime: any;
+  registrationEndTime: any;
+  testStartTime: any;
+  testEndTime: any;
+  resultTime: any;
+  totalQuestions: number;
+  createdAt: any;
+  updatedAt: any;
+  status: 'upcoming' | 'registration' | 'ongoing' | 'completed';
+  entryFee: number;
+  timeLimit: number;
+}
+
 export const getMegaTestLeaderboard = async (
   megaTestId: string
 ): Promise<MegaTestLeaderboardEntry[]> => {
@@ -46,4 +63,50 @@ export const getMegaTestLeaderboard = async (
     { headers: { Authorization: `Bearer ${token}` } }
   );
   return res.data;
+};
+
+export const getMegaTests = async (): Promise<MegaTest[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const registerForMegaTest = async (
+  megaTestId: string,
+  userId: string,
+  username: string,
+  email: string
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/register`,
+    { userId, username, email },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};
+
+export const isUserRegistered = async (
+  megaTestId: string,
+  userId: string
+): Promise<boolean> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/mega-tests/${megaTestId}/registration-status/${userId}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data.registered;
+};
+
+export const hasUserSubmittedMegaTest = async (
+  megaTestId: string,
+  userId: string
+): Promise<boolean> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/mega-tests/${megaTestId}/submission-status/${userId}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return res.data.submitted;
 };

--- a/src/services/api/paidContent.ts
+++ b/src/services/api/paidContent.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { getAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface PaidContent {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  pdfUrl: string;
+  thumbnailUrl?: string;
+}
+
+export const getPaidContents = async (): Promise<PaidContent[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/paid-contents`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getPurchasedContents = async (userId: string): Promise<PaidContent[]> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/users/purchased-content/${userId}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const purchaseContent = async (userId: string, contentId: string): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/users/purchased-content/${userId}`,
+    { contentId },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};


### PR DESCRIPTION
## Summary
- add paid content backend controller and routes
- extend mega test controller and routes for new APIs
- expose paid content list and purchase endpoints
- call backend APIs instead of Firestore in pages

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e73584010832bbd333648a8449fc1