### PR TITLE
Make question paper routes public

### DIFF
--- a/backend/src/routes/questionPaperRoutes.ts
+++ b/backend/src/routes/questionPaperRoutes.ts
@@ -1,13 +1,10 @@
 import express from 'express';
-import { authenticateUser } from '../middleware/auth.js';
 import {
   getQuestionPaperCategories,
   getQuestionPapersByCategory,
 } from '../controllers/questionPaperController.js';
 
 const router = express.Router();
-
-router.use(authenticateUser);
 
 router.get('/categories', getQuestionPaperCategories);
 router.get('/categories/:categoryId/papers', getQuestionPapersByCategory);


### PR DESCRIPTION
## Summary
- remove auth middleware from question paper routes so `/question-papers` is publicly accessible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e8699e90c832b8235fc6dc687976f