### PR TITLE
Route Firestore features through backend

### DIFF
--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -6,18 +6,24 @@ import {
   getMegaTests,
   registerForMegaTest,
   isUserRegistered,
-  hasUserSubmittedMegaTest
+  hasUserSubmittedMegaTest,
+  getMegaTestById,
+  getMegaTestPrizes,
+  submitMegaTestResult
 } from '../controllers/megaTestController.js';
 
 const router = express.Router();
 
 router.get('/', getMegaTests);
 router.get('/:megaTestId/leaderboard', getMegaTestLeaderboard);
+router.get('/:megaTestId', getMegaTestById);
+router.get('/:megaTestId/prizes', getMegaTestPrizes);
 
 router.use(authenticateUser);
 router.post('/:megaTestId/register', registerForMegaTest);
 router.get('/:megaTestId/registration-status/:userId', isUserRegistered);
 router.get('/:megaTestId/submission-status/:userId', hasUserSubmittedMegaTest);
+router.post('/:megaTestId/submit', submitMegaTestResult);
 router.post('/:megaTestId/prize-claims', submitPrizeClaim);
 
 export default router;

--- a/src/components/MegaTestLeaderboard.tsx
+++ b/src/components/MegaTestLeaderboard.tsx
@@ -5,7 +5,7 @@ import { Trophy, Medal, User, Search, ChevronLeft, ChevronRight } from 'lucide-r
 import { MegaTestLeaderboardEntry } from '../services/api/megaTest';
 import { getMegaTestLeaderboard } from '../services/api/megaTest';
 import { useQuery } from '@tanstack/react-query';
-import { getUserById } from '../services/firebase/auth';
+import { getUserProfile } from '../services/api/user';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useAuth } from '../App';
@@ -29,11 +29,10 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
 
       const entriesWithUserDetails = await Promise.all(
         snapshot.map(async (entry) => {
-          const user = await getUserById(entry.userId);
+          const user = await getUserProfile(entry.userId);
           return {
             ...entry,
-            userName: user?.username || user?.displayName || 'Anonymous User',
-            userPhotoURL: user?.photoURL,
+            userName: user?.username || 'Anonymous User',
           };
         })
       );
@@ -132,17 +131,9 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  {entry.userPhotoURL ? (
-                    <img
-                      src={entry.userPhotoURL}
-                      alt={entry.userName}
-                      className="w-6 h-6 rounded-full"
-                    />
-                  ) : (
-                    <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
-                      <User className="h-4 w-4 text-muted-foreground" />
-                    </div>
-                  )}
+                  <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                  </div>
                   <span className="font-medium">{entry.userName}</span>
                 </div>
               </div>

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { doc, getDoc } from 'firebase/firestore';
-import { db } from '../services/firebase/config';
+import { getContent } from '../services/api/content';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -12,14 +11,7 @@ const Guide = () => {
   
   const { data: guideData, isLoading, error } = useQuery({
     queryKey: ['guide'],
-    queryFn: async () => {
-      const docRef = doc(db, 'content', 'guide');
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return docSnap.data();
-      }
-      return { content: '' };
-    }
+    queryFn: () => getContent('guide')
   });
 
   if (isLoading) {

--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -4,7 +4,12 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Loader2, ChevronRight, ChevronLeft, Clock, CreditCard, Trophy } from 'lucide-react';
-import { getMegaTestById, submitMegaTestResult, MegaTestQuestion, hasUserSubmittedMegaTest } from '@/services/firebase/quiz';
+import {
+  getMegaTestById,
+  submitMegaTestResult,
+  MegaTestQuestion,
+  hasUserSubmittedMegaTest
+} from '@/services/api/megaTest';
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { toast } from 'sonner';

--- a/src/pages/MegaTestPrizes.tsx
+++ b/src/pages/MegaTestPrizes.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, Trophy } from 'lucide-react';
-import { getMegaTestById, getMegaTestPrizes } from '@/services/firebase/quiz';
+import { getMegaTestById, getMegaTestPrizes } from '@/services/api/megaTest';
 
 const MegaTestPrizesPage = () => {
   const { megaTestId } = useParams();

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -54,6 +54,18 @@ export interface MegaTest {
   timeLimit: number;
 }
 
+export interface MegaTestQuestion {
+  id: string;
+  text: string;
+  options: any[];
+  correctAnswer: string;
+}
+
+export interface MegaTestPrize {
+  rank: number;
+  prize: string;
+}
+
 export const getMegaTestLeaderboard = async (
   megaTestId: string
 ): Promise<MegaTestLeaderboardEntry[]> => {
@@ -109,4 +121,37 @@ export const hasUserSubmittedMegaTest = async (
     { headers: { Authorization: `Bearer ${token}` } }
   );
   return res.data.submitted;
+};
+
+export const getMegaTestById = async (
+  megaTestId: string
+): Promise<{ megaTest: MegaTest; questions: MegaTestQuestion[] }> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests/${megaTestId}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  return res.data;
+};
+
+export const getMegaTestPrizes = async (
+  megaTestId: string
+): Promise<MegaTestPrize[]> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.get(`${API_URL}/api/mega-tests/${megaTestId}/prizes`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  return res.data;
+};
+
+export const submitMegaTestResult = async (
+  megaTestId: string,
+  score: number,
+  completionTime: number
+): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/submit`,
+    { score, completionTime },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
 };


### PR DESCRIPTION
## Summary
- add backend endpoints for mega test details, prizes and result submission
- expose new mega test API utilities
- fetch paid content and guide data from backend
- move mega test pages and leaderboard to API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686e8b28cea4832b8ac4f0f5600d74ab