### PR TITLE
Secure MegaTest flow via backend

### DIFF
--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -16,7 +16,7 @@ const router = express.Router();
 
 router.get('/', getMegaTests);
 router.get('/:megaTestId/leaderboard', getMegaTestLeaderboard);
-router.get('/:megaTestId', getMegaTestById);
+router.get('/:megaTestId', authenticateUser, getMegaTestById);
 router.get('/:megaTestId/prizes', getMegaTestPrizes);
 
 router.use(authenticateUser);

--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -202,23 +202,13 @@ const MegaTest = () => {
   const handleSubmit = async () => {
     if (!megaTest || !user) return;
 
-    let totalScore = 0;
-    const totalQuestions = questions.length;
-
-    questions.forEach(question => {
-      const selectedAnswer = selectedAnswers[question.id];
-      if (selectedAnswer === question.correctAnswer) {
-        totalScore++;
-      }
-    });
-
     const completionTime = Math.floor((Date.now() - startTime) / 1000); // Convert to seconds
 
-    setScore(totalScore);
     setIsSubmitted(true);
 
     try {
-      await submitMegaTestResult(megaTest.id, user.uid, totalScore, completionTime);
+      const res = await submitMegaTestResult(megaTest.id, selectedAnswers, completionTime);
+      setScore(res.score);
       toast.success('Quiz submitted successfully!');
     } catch (error) {
       toast.error('Failed to submit quiz. Please try again.');

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -58,7 +58,7 @@ export interface MegaTestQuestion {
   id: string;
   text: string;
   options: any[];
-  correctAnswer: string;
+  correctAnswer?: string;
 }
 
 export interface MegaTestPrize {
@@ -143,15 +143,25 @@ export const getMegaTestPrizes = async (
   return res.data;
 };
 
+export interface MegaTestAnswers {
+  [questionId: string]: string;
+}
+
+export interface SubmitMegaTestResultResponse {
+  success: boolean;
+  score: number;
+}
+
 export const submitMegaTestResult = async (
   megaTestId: string,
-  score: number,
+  answers: MegaTestAnswers,
   completionTime: number
-): Promise<void> => {
+): Promise<SubmitMegaTestResultResponse> => {
   const token = await getAuthToken();
-  await axios.post(
+  const res = await axios.post(
     `${API_URL}/api/mega-tests/${megaTestId}/submit`,
-    { score, completionTime },
+    { answers, completionTime },
     { headers: { Authorization: `Bearer ${token}` } }
   );
+  return res.data;
 };


### PR DESCRIPTION
## Summary
- lock down mega test questions route
- omit correct answers from mega test question payload
- score mega test submissions in backend
- update API client and MegaTest page for new submission flow

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `cd backend && npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_686e9cee4d1c832bad3efe23cbe42ad8