### PR TITLE
Switch localStorage to secure cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "firebase": "^10.10.0",
         "framer-motion": "^12.4.10",
         "input-otp": "^1.2.4",
+        "js-cookie": "^3.0.5",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "papaparse": "^5.5.3",
@@ -6850,6 +6851,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "firebase": "^10.10.0",
     "framer-motion": "^12.4.10",
     "input-otp": "^1.2.4",
+    "js-cookie": "^3.0.5",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "papaparse": "^5.5.3",

--- a/src/components/SessionTimer.tsx
+++ b/src/components/SessionTimer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { Clock } from 'lucide-react';
 import { logoutUser } from '../services/firebase/auth';
 import { useNavigate } from 'react-router-dom';
+import { removeCookie } from '@/utils/cookies';
 
 const SESSION_TIMEOUT = 10 * 60 * 1000; // 10 minutes in milliseconds
 
@@ -20,8 +21,8 @@ export const SessionTimer = ({ isAuthenticated, onReset, className, hideIcon = f
   const handleLogout = async () => {
     try {
       await logoutUser();
-      localStorage.removeItem('user');
-      localStorage.removeItem('adminAuth');
+      removeCookie('user');
+      removeCookie('adminAuth');
       navigate('/auth');
     } catch (error) {
       console.error('Error logging out:', error);

--- a/src/hooks/useSessionTimeout.ts
+++ b/src/hooks/useSessionTimeout.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { logoutUser } from '../services/firebase/auth';
+import { removeCookie } from '@/utils/cookies';
 
 const SESSION_TIMEOUT = 10 * 60 * 1000; // 10 minutes in milliseconds
 
@@ -12,8 +13,8 @@ export const useSessionTimeout = (isAuthenticated: boolean) => {
   const handleLogout = async () => {
     try {
       await logoutUser();
-      localStorage.removeItem('user');
-      localStorage.removeItem('adminAuth');
+      removeCookie('user');
+      removeCookie('adminAuth');
       toast.info('Your session has expired. Please log in again.');
       navigate('/auth');
     } catch (error) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,6 +18,7 @@ import { LogOut, ShieldAlert, Trophy, Clock, ListChecks, CreditCard, Book, User,
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import MegaTestLeaderboard from "../components/MegaTestLeaderboard";
+import { getCookie } from '@/utils/cookies';
 import MegaTestPrizes from "../components/MegaTestPrizes";
 import { 
   DropdownMenu, 
@@ -155,7 +156,7 @@ const Home = () => {
   
   useEffect(() => {
     try {
-      const adminAuth = localStorage.getItem('adminAuth');
+      const adminAuth = getCookie('adminAuth');
       if (adminAuth) {
         const parsedAuth = JSON.parse(adminAuth);
         if (parsedAuth && parsedAuth.isAdmin) {

--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getCookie, setCookie, removeCookie } from '@/utils/cookies';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -38,10 +39,10 @@ const MegaTest = () => {
   const [startTime, setStartTime] = useState<number>(0);
   const [showExitDialog, setShowExitDialog] = useState(false);
 
-  // Load saved quiz state from localStorage
+  // Load saved quiz state from cookies
   useEffect(() => {
     if (megaTestId && user) {
-      const savedState = localStorage.getItem(`megaTest_${megaTestId}_${user.uid}`);
+      const savedState = getCookie(`megaTest_${megaTestId}_${user.uid}`);
       if (savedState) {
         const { currentQuestionIndex: savedIndex, selectedAnswers: savedAnswers, skippedQuestions: savedSkipped, isStarted, startTime: savedStartTime } = JSON.parse(savedState);
         setCurrentQuestionIndex(savedIndex);
@@ -53,7 +54,7 @@ const MegaTest = () => {
     }
   }, [megaTestId, user]);
 
-  // Save quiz state to localStorage
+  // Save quiz state to cookies
   useEffect(() => {
     if (megaTestId && user && isQuizStarted) {
       const stateToSave = {
@@ -63,14 +64,14 @@ const MegaTest = () => {
         isStarted: isQuizStarted,
         startTime
       };
-      localStorage.setItem(`megaTest_${megaTestId}_${user.uid}`, JSON.stringify(stateToSave));
+      setCookie(`megaTest_${megaTestId}_${user.uid}`, JSON.stringify(stateToSave));
     }
   }, [megaTestId, user, currentQuestionIndex, selectedAnswers, skippedQuestions, isQuizStarted, startTime]);
 
   // Clear saved state when quiz is submitted
   useEffect(() => {
     if (isSubmitted && megaTestId && user) {
-      localStorage.removeItem(`megaTest_${megaTestId}_${user.uid}`);
+      removeCookie(`megaTest_${megaTestId}_${user.uid}`);
     }
   }, [isSubmitted, megaTestId, user]);
 

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -1,6 +1,7 @@
 import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, sendPasswordResetEmail, signOut, updateProfile, onIdTokenChanged } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
 import { app, db } from '../firebase/config';
+import { setCookie, getCookie, removeCookie } from '@/utils/cookies';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
@@ -63,8 +64,8 @@ export const loginUser = async (email: string, password: string): Promise<LoginR
     // Get fresh token
     const token = await user.getIdToken(true);
     
-    // Store user data in localStorage
-    localStorage.setItem('user', JSON.stringify({
+    // Store user data in cookie
+    setCookie('user', JSON.stringify({
       id: user.uid,
       email: user.email,
       username: user.displayName || '',
@@ -124,8 +125,8 @@ export const registerUser = async (email: string, password: string, username: st
       lastUpdated: new Date().toISOString(),
     });
     
-    // Store user data in localStorage
-    localStorage.setItem('user', JSON.stringify({
+    // Store user data in cookie
+    setCookie('user', JSON.stringify({
       id: user.uid,
       email: user.email,
       username: username,
@@ -166,7 +167,7 @@ export const logoutUser = async () => {
   try {
     const auth = getAuth(app);
     await signOut(auth);
-    localStorage.removeItem('user');
+    removeCookie('user');
     stopTokenRefresh();
   } catch (error) {
     console.error('Error logging out:', error);
@@ -175,7 +176,7 @@ export const logoutUser = async () => {
 };
 
 export const getCurrentUser = (): { id: string; email: string; username: string } | null => {
-  const userStr = localStorage.getItem('user');
+  const userStr = getCookie('user');
   if (!userStr) return null;
   return JSON.parse(userStr);
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,5 @@
 import { api } from '../api/config';
+import { removeCookie } from '@/utils/cookies';
 
 export const login = async (credentials: { email: string; password: string }) => {
   try {
@@ -13,8 +14,7 @@ export const logout = async () => {
   try {
     await api.post('/api/auth/logout');
     // Clear any client-side storage
-    localStorage.clear();
-    sessionStorage.clear();
+    removeCookie('user');
     // Redirect to login page
     window.location.href = '/login';
   } catch (error) {

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,13 @@
+import Cookies from 'js-cookie';
+
+export const setCookie = (key: string, value: string, expiresDays = 7) => {
+  Cookies.set(key, value, { expires: expiresDays, secure: true, sameSite: 'strict' });
+};
+
+export const getCookie = (key: string): string | undefined => {
+  return Cookies.get(key);
+};
+
+export const removeCookie = (key: string) => {
+  Cookies.remove(key);
+};

--- a/src/utils/deviceId.ts
+++ b/src/utils/deviceId.ts
@@ -1,12 +1,13 @@
 import { v4 as uuidv4 } from 'uuid';
+import { getCookie, setCookie } from '@/utils/cookies';
 
 const DEVICE_ID_KEY = 'device_id';
 
 export function getDeviceId(): string {
-  let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+  let deviceId = getCookie(DEVICE_ID_KEY);
   if (!deviceId) {
     deviceId = uuidv4();
-    localStorage.setItem(DEVICE_ID_KEY, deviceId);
+    setCookie(DEVICE_ID_KEY, deviceId, 365);
   }
   return deviceId;
-} 
+}


### PR DESCRIPTION
## Summary
- add js-cookie library and cookie utils
- switch session-related storage to secure cookies

## Testing
- `npm run build`
- `npm run lint` *(fails: no-useless-catch etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68764d2fe0b8832bb793a28249328755