### PR TITLE
Secure PDF downloads via backend

### DIFF
--- a/backend/src/config/firebase.ts
+++ b/backend/src/config/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp, cert, getApps, ServiceAccount } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { getAuth } from 'firebase-admin/auth';
+import { getStorage } from 'firebase-admin/storage';
 import dotenv from 'dotenv';
 
 // Load environment variables
@@ -51,8 +52,9 @@ const initializeFirebaseAdmin = () => {
   
   return {
     db: getFirestore(),
-    auth: getAuth()
+    auth: getAuth(),
+    storage: getStorage()
   };
 };
 
-export const { db, auth } = initializeFirebaseAdmin(); 
+export const { db, auth, storage } = initializeFirebaseAdmin();

--- a/backend/src/controllers/paidContentController.ts
+++ b/backend/src/controllers/paidContentController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { db } from '../config/firebase.js';
+import { db, storage } from '../config/firebase.js';
 
 export const getPaidContents = async (_req: Request, res: Response) => {
   try {
@@ -71,5 +71,69 @@ export const purchaseContent = async (req: Request, res: Response) => {
   } catch (error: any) {
     console.error('Error processing purchase:', error);
     res.status(500).json({ error: error.message || 'Failed to process purchase' });
+  }
+};
+
+const extractFilePath = (url: string): string | null => {
+  const match = decodeURIComponent(url).match(/\/o\/(.+)\?/);
+  return match ? match[1] : null;
+};
+
+export const downloadPaidContent = async (req: Request, res: Response) => {
+  try {
+    const { contentId } = req.params;
+    const docSnap = await db.collection('paidContents').doc(contentId).get();
+    if (!docSnap.exists) {
+      return res.status(404).json({ error: 'Content not found' });
+    }
+    const data = docSnap.data() as any;
+    const filePath = extractFilePath(data.pdfUrl);
+    if (!filePath) {
+      return res.status(500).json({ error: 'Invalid file path' });
+    }
+
+    const file = storage.bucket().file(filePath);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${file.name.split('/').pop()}"`);
+    file.createReadStream()
+      .on('error', err => {
+        console.error('Error streaming file:', err);
+        res.status(500).end();
+      })
+      .pipe(res);
+  } catch (error) {
+    console.error('Error downloading paid content:', error);
+    res.status(500).json({ error: 'Failed to download content' });
+  }
+};
+
+export const downloadSampleContent = async (req: Request, res: Response) => {
+  try {
+    const { contentId } = req.params;
+    const docSnap = await db.collection('paidContents').doc(contentId).get();
+    if (!docSnap.exists) {
+      return res.status(404).json({ error: 'Content not found' });
+    }
+    const data = docSnap.data() as any;
+    if (!data.samplePdfUrl) {
+      return res.status(404).json({ error: 'Sample not available' });
+    }
+    const filePath = extractFilePath(data.samplePdfUrl);
+    if (!filePath) {
+      return res.status(500).json({ error: 'Invalid file path' });
+    }
+
+    const file = storage.bucket().file(filePath);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${file.name.split('/').pop()}"`);
+    file.createReadStream()
+      .on('error', err => {
+        console.error('Error streaming file:', err);
+        res.status(500).end();
+      })
+      .pipe(res);
+  } catch (error) {
+    console.error('Error downloading sample pdf:', error);
+    res.status(500).json({ error: 'Failed to download sample' });
   }
 };

--- a/backend/src/controllers/questionPaperController.ts
+++ b/backend/src/controllers/questionPaperController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { db } from '../config/firebase.js';
+import { db, storage } from '../config/firebase.js';
 
 export const getQuestionPaperCategories = async (_req: Request, res: Response) => {
   try {
@@ -36,5 +36,38 @@ export const getQuestionPapersByCategory = async (req: Request, res: Response) =
   } catch (error) {
     console.error('Error fetching question papers:', error);
     res.status(500).json({ error: 'Failed to fetch question papers' });
+  }
+};
+
+const extractFilePath = (url: string): string | null => {
+  const match = decodeURIComponent(url).match(/\/o\/(.+)\?/);
+  return match ? match[1] : null;
+};
+
+export const downloadQuestionPaper = async (req: Request, res: Response) => {
+  try {
+    const { paperId } = req.params;
+    const docSnap = await db.collection('questionPapers').doc(paperId).get();
+    if (!docSnap.exists) {
+      return res.status(404).json({ error: 'Paper not found' });
+    }
+    const data = docSnap.data() as any;
+    const filePath = extractFilePath(data.fileUrl);
+    if (!filePath) {
+      return res.status(500).json({ error: 'Invalid file path' });
+    }
+
+    const file = storage.bucket().file(filePath);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${file.name.split('/').pop()}"`);
+    file.createReadStream()
+      .on('error', err => {
+        console.error('Error streaming file:', err);
+        res.status(500).end();
+      })
+      .pipe(res);
+  } catch (error) {
+    console.error('Error downloading question paper:', error);
+    res.status(500).json({ error: 'Failed to download question paper' });
   }
 };

--- a/backend/src/routes/paidContentRoutes.ts
+++ b/backend/src/routes/paidContentRoutes.ts
@@ -1,6 +1,12 @@
 import express from 'express';
-import { getPaidContents } from '../controllers/paidContentController.js';
+import {
+  getPaidContents,
+  downloadPaidContent,
+  downloadSampleContent,
+} from '../controllers/paidContentController.js';
 
 const router = express.Router();
 router.get('/', getPaidContents);
+router.get('/:contentId/download', downloadPaidContent);
+router.get('/:contentId/sample', downloadSampleContent);
 export default router;

--- a/backend/src/routes/questionPaperRoutes.ts
+++ b/backend/src/routes/questionPaperRoutes.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import {
   getQuestionPaperCategories,
   getQuestionPapersByCategory,
+  downloadQuestionPaper,
 } from '../controllers/questionPaperController.js';
 
 const router = express.Router();
 
 router.get('/categories', getQuestionPaperCategories);
 router.get('/categories/:categoryId/papers', getQuestionPapersByCategory);
+router.get('/papers/:paperId/download', downloadQuestionPaper);
 
 export default router;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -28,7 +28,11 @@ import {
 } from "../components/ui/dropdown-menu";
 import { SessionTimer } from '../components/SessionTimer';
 import { useSessionTimeout } from '../hooks/useSessionTimeout';
-import { getPaidContents, purchaseContent } from '../services/api/paidContent';
+import {
+  getPaidContents,
+  purchaseContent,
+  downloadPaidContent,
+} from '../services/api/paidContent';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { captureUserIP } from '../services/api/user';
@@ -209,7 +213,9 @@ const Home = () => {
       setIsPurchasing(true);
       await purchaseContent(user.uid, content.id);
       toast.success('Purchase successful!');
-      window.open(content.pdfUrl, '_blank');
+      const blob = await downloadPaidContent(content.id);
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
       
     } catch (error) {
       console.error('Error processing purchase:', error);

--- a/src/pages/PaidContent.tsx
+++ b/src/pages/PaidContent.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect } from 'react';
-import { getPaidContents, purchaseContent } from '../services/api/paidContent';
+import {
+  getPaidContents,
+  purchaseContent,
+  downloadPaidContent,
+  downloadSampleContent,
+} from '../services/api/paidContent';
 import { useAuth } from '../App';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -66,7 +71,9 @@ export default function PaidContentPage() { // Renamed component to avoid confli
 
       toast.success('Purchase successful!');
 
-      window.open(content.pdfUrl, '_blank');
+      const blob = await downloadPaidContent(content.id);
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
       
     } catch (error) {
       console.error('Error processing purchase:', error);
@@ -130,7 +137,11 @@ export default function PaidContentPage() { // Renamed component to avoid confli
                   <Button
                     variant="outline"
                     className="w-full mb-2 border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-gray-600 dark:text-indigo-300 dark:hover:bg-gray-700"
-                    onClick={() => window.open(content.samplePdfUrl, '_blank')}
+                    onClick={async () => {
+                      const blob = await downloadSampleContent(content.id);
+                      const url = URL.createObjectURL(blob);
+                      window.open(url, '_blank');
+                    }}
                   >
                     <FileText className="h-4 w-4 mr-2" />
                     View Sample

--- a/src/pages/PurchasedContent.tsx
+++ b/src/pages/PurchasedContent.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getPurchasedContents } from '../services/api/paidContent';
+import { getPurchasedContents, downloadPaidContent } from '../services/api/paidContent';
 import { useAuth } from '../App';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -45,8 +45,14 @@ export default function PurchasedContentPage() { // Renamed component
     }
   };
 
-  const handleViewContent = (pdfUrl: string) => {
-    window.open(pdfUrl, '_blank');
+  const handleViewContent = async (contentId: string) => {
+    try {
+      const blob = await downloadPaidContent(contentId);
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
+    } catch (err) {
+      console.error('Failed to open content', err);
+    }
   };
 
   if (loading) {
@@ -137,7 +143,7 @@ export default function PurchasedContentPage() { // Renamed component
                 </CardContent>
                 <CardFooter>
                   <Button
-                    onClick={() => handleViewContent(content.pdfUrl)}
+                    onClick={() => handleViewContent(content.id)}
                     className="w-full bg-indigo-600 hover:bg-indigo-700 text-white transition-colors duration-300 group-hover:scale-[1.02]"
                   >
                     <ExternalLink className="h-4 w-4 mr-2" /> {/* Added mr-2 for spacing */}

--- a/src/pages/QuestionPaperCategory.tsx
+++ b/src/pages/QuestionPaperCategory.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { getQuestionPapersByCategory, getQuestionPaperCategories } from '../services/api/questionPapers';
+import { getQuestionPapersByCategory, getQuestionPaperCategories, downloadQuestionPaper } from '../services/api/questionPapers';
 import type { QuestionPaper, QuestionPaperCategory } from '../services/api/questionPapers';
 import { ArrowLeft, Download, Calendar, FileText, Clock } from 'lucide-react';
 import { Button } from '../components/ui/button';
@@ -38,6 +38,16 @@ export default function QuestionPaperCategory() {
 
     fetchData();
   }, [categoryId]);
+
+  const handleDownload = async (paperId: string) => {
+    try {
+      const blob = await downloadQuestionPaper(paperId);
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
+    } catch (err) {
+      console.error('Failed to download paper', err);
+    }
+  };
 
   if (loading) {
     return (
@@ -108,18 +118,12 @@ export default function QuestionPaperCategory() {
               </div>
             </CardContent>
             <CardFooter className="p-3 md:p-6 pt-0">
-              <Button 
+              <Button
                 className="w-full group-hover:bg-blue-600 transition-colors text-sm md:text-base"
-                asChild
+                onClick={() => handleDownload(paper.id)}
               >
-                <a
-                  href={paper.fileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
-                  Download
-                </a>
+                <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
+                Download
               </Button>
             </CardFooter>
           </Card>

--- a/src/services/api/paidContent.ts
+++ b/src/services/api/paidContent.ts
@@ -36,3 +36,21 @@ export const purchaseContent = async (userId: string, contentId: string): Promis
     { headers: { Authorization: `Bearer ${token}` } }
   );
 };
+
+export const downloadPaidContent = async (contentId: string): Promise<Blob> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/paid-contents/${contentId}/download`, {
+    responseType: 'blob',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const downloadSampleContent = async (contentId: string): Promise<Blob> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/paid-contents/${contentId}/sample`, {
+    responseType: 'blob',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};

--- a/src/services/api/questionPapers.ts
+++ b/src/services/api/questionPapers.ts
@@ -37,3 +37,12 @@ export const getQuestionPapersByCategory = async (categoryId: string): Promise<Q
   );
   return res.data;
 };
+
+export const downloadQuestionPaper = async (paperId: string): Promise<Blob> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/question-papers/papers/${paperId}/download`, {
+    responseType: 'blob',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- include Firebase Storage in backend setup
- add streaming download endpoints for question papers and paid content
- expose download routes
- update API services to use new routes
- open PDFs via blob URLs so Firebase URLs stay hidden

## Testing
- `npm run lint` *(fails: 101 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68766756f418832bbaacdcdfeb165faf