### PR TITLE
Secure paid-content download

### DIFF
--- a/backend/src/routes/paidContentRoutes.ts
+++ b/backend/src/routes/paidContentRoutes.ts
@@ -1,6 +1,8 @@
 import express from 'express';
-import { getPaidContents } from '../controllers/paidContentController.js';
+import { getPaidContents, downloadPaidContent } from '../controllers/paidContentController.js';
+import { authenticateUser } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/', getPaidContents);
+router.get('/:contentId/download', authenticateUser, downloadPaidContent);
 export default router;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -28,7 +28,7 @@ import {
 } from "../components/ui/dropdown-menu";
 import { SessionTimer } from '../components/SessionTimer';
 import { useSessionTimeout } from '../hooks/useSessionTimeout';
-import { getPaidContents, purchaseContent } from '../services/api/paidContent';
+import { getPaidContents, purchaseContent, downloadContent } from '../services/api/paidContent';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { captureUserIP } from '../services/api/user';
@@ -209,7 +209,19 @@ const Home = () => {
       setIsPurchasing(true);
       await purchaseContent(user.uid, content.id);
       toast.success('Purchase successful!');
-      window.open(content.pdfUrl, '_blank');
+
+      try {
+        const blob = await downloadContent(content.id);
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${content.title}.pdf`;
+        link.click();
+        window.URL.revokeObjectURL(url);
+      } catch (err) {
+        console.error('Failed to download file:', err);
+        toast.error('Unable to download file');
+      }
       
     } catch (error) {
       console.error('Error processing purchase:', error);

--- a/src/pages/PaidContent.tsx
+++ b/src/pages/PaidContent.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getPaidContents, purchaseContent } from '../services/api/paidContent';
+import { getPaidContents, purchaseContent, downloadContent } from '../services/api/paidContent';
 import { useAuth } from '../App';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -66,7 +66,18 @@ export default function PaidContentPage() { // Renamed component to avoid confli
 
       toast.success('Purchase successful!');
 
-      window.open(content.pdfUrl, '_blank');
+      try {
+        const blob = await downloadContent(content.id);
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${content.title}.pdf`;
+        link.click();
+        window.URL.revokeObjectURL(url);
+      } catch (err) {
+        console.error('Failed to download file:', err);
+        toast.error('Unable to download file');
+      }
       
     } catch (error) {
       console.error('Error processing purchase:', error);

--- a/src/pages/PurchasedContent.tsx
+++ b/src/pages/PurchasedContent.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getPurchasedContents } from '../services/api/paidContent';
+import { getPurchasedContents, downloadContent } from '../services/api/paidContent';
 import { useAuth } from '../App';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
@@ -45,8 +45,19 @@ export default function PurchasedContentPage() { // Renamed component
     }
   };
 
-  const handleViewContent = (pdfUrl: string) => {
-    window.open(pdfUrl, '_blank');
+  const handleViewContent = async (id: string, title: string) => {
+    try {
+      const blob = await downloadContent(id);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${title}.pdf`;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to download content:', error);
+      toast.error('Failed to download file');
+    }
   };
 
   if (loading) {
@@ -137,7 +148,7 @@ export default function PurchasedContentPage() { // Renamed component
                 </CardContent>
                 <CardFooter>
                   <Button
-                    onClick={() => handleViewContent(content.pdfUrl)}
+                    onClick={() => handleViewContent(content.id, content.title)}
                     className="w-full bg-indigo-600 hover:bg-indigo-700 text-white transition-colors duration-300 group-hover:scale-[1.02]"
                   >
                     <ExternalLink className="h-4 w-4 mr-2" /> {/* Added mr-2 for spacing */}

--- a/src/services/api/paidContent.ts
+++ b/src/services/api/paidContent.ts
@@ -36,3 +36,12 @@ export const purchaseContent = async (userId: string, contentId: string): Promis
     { headers: { Authorization: `Bearer ${token}` } }
   );
 };
+
+export const downloadContent = async (contentId: string): Promise<Blob> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/paid-contents/${contentId}/download`, {
+    headers: { Authorization: `Bearer ${token}` },
+    responseType: 'blob'
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- serve PDF downloads through backend
- route downloads via auth middleware
- use download endpoint in client

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68766e9fbde4832b83425a50c0ce11da