### PR TITLE
Add secure question paper download

### DIFF
--- a/backend/src/routes/questionPaperRoutes.ts
+++ b/backend/src/routes/questionPaperRoutes.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import {
   getQuestionPaperCategories,
   getQuestionPapersByCategory,
+  downloadQuestionPaper,
 } from '../controllers/questionPaperController.js';
 
 const router = express.Router();
 
 router.get('/categories', getQuestionPaperCategories);
 router.get('/categories/:categoryId/papers', getQuestionPapersByCategory);
+router.get('/papers/:paperId/download', downloadQuestionPaper);
 
 export default router;

--- a/src/pages/QuestionPaperCategory.tsx
+++ b/src/pages/QuestionPaperCategory.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { getQuestionPapersByCategory, getQuestionPaperCategories } from '../services/api/questionPapers';
+import {
+  getQuestionPapersByCategory,
+  getQuestionPaperCategories,
+  downloadQuestionPaper
+} from '../services/api/questionPapers';
 import type { QuestionPaper, QuestionPaperCategory } from '../services/api/questionPapers';
 import { ArrowLeft, Download, Calendar, FileText, Clock } from 'lucide-react';
 import { Button } from '../components/ui/button';
@@ -38,6 +42,20 @@ export default function QuestionPaperCategory() {
 
     fetchData();
   }, [categoryId]);
+
+  const handleDownload = async (paper: QuestionPaper) => {
+    try {
+      const blob = await downloadQuestionPaper(paper.id);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${paper.title}.pdf`;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to download file:', err);
+    }
+  };
 
   if (loading) {
     return (
@@ -108,18 +126,12 @@ export default function QuestionPaperCategory() {
               </div>
             </CardContent>
             <CardFooter className="p-3 md:p-6 pt-0">
-              <Button 
+              <Button
                 className="w-full group-hover:bg-blue-600 transition-colors text-sm md:text-base"
-                asChild
+                onClick={() => handleDownload(paper)}
               >
-                <a
-                  href={paper.fileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
-                  Download
-                </a>
+                <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
+                Download
               </Button>
             </CardFooter>
           </Card>

--- a/src/services/api/questionPapers.ts
+++ b/src/services/api/questionPapers.ts
@@ -37,3 +37,12 @@ export const getQuestionPapersByCategory = async (categoryId: string): Promise<Q
   );
   return res.data;
 };
+
+export const downloadQuestionPaper = async (paperId: string): Promise<Blob> => {
+  const token = await getAuthToken();
+  const res = await axios.get(`${API_URL}/api/question-papers/papers/${paperId}/download`, {
+    headers: { Authorization: `Bearer ${token}` },
+    responseType: 'blob'
+  });
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- add secure download endpoint for question papers
- call new API on the frontend to fetch PDFs without exposing storage URLs

## Testing
- `npx eslint .` *(fails: unexpected any errors)*
- `cd backend && npx eslint .` *(fails: unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687674a6f10c832b8f41a99889ba3498