### PR TITLE
Improve Firebase admin auth security

### DIFF
--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -58,4 +58,22 @@ export const updateUserRole = async (req: Request, res: Response) => {
     console.error('Error updating user role:', error);
     res.status(500).json({ error: 'Failed to update user role' });
   }
-}; 
+};
+
+// Return the authenticated admin's status
+export const getAdminStatus = (req: Request, res: Response) => {
+  try {
+    if (!req.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    res.json({
+      isAdmin: true,
+      uid: req.admin.uid,
+      email: req.admin.email
+    });
+  } catch (error) {
+    console.error('Error getting admin status:', error);
+    res.status(500).json({ error: 'Failed to get admin status' });
+  }
+};

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { auth } from '../config/firebase.js';
 import { db } from '../config/firebase.js';
+import { isDevelopment } from '../config/env.js';
 
 // Extend Express Request type to include user
 declare module 'express' {
@@ -18,8 +19,10 @@ export const authenticateUser = async (req: Request, res: Response, next: NextFu
   try {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
-      console.log('No Bearer token found in Authorization header');
-      return res.status(401).json({ 
+      if (isDevelopment()) {
+        console.log('No Bearer token found in Authorization header');
+      }
+      return res.status(401).json({
         error: 'No token provided',
         requiresAuth: true
       });
@@ -28,9 +31,13 @@ export const authenticateUser = async (req: Request, res: Response, next: NextFu
     const token = authHeader.split('Bearer ')[1];
     
     try {
-      console.log('Verifying token with Firebase Admin...');
+      if (isDevelopment()) {
+        console.log('Verifying token with Firebase Admin...');
+      }
       const decodedToken = await auth.verifyIdToken(token);
-      console.log('Token verified successfully. User ID:', decodedToken.uid);
+      if (isDevelopment()) {
+        console.log('Token verified successfully. User ID:', decodedToken.uid);
+      }
       
       // Get user from database (optional - user document might not exist yet)
       const userDoc = await db.collection('users').doc(decodedToken.uid).get();

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { verifyFirebaseAdmin } from '../middleware/firebaseAdminAuth.js';
-import { getAllUsers, getAllBalances, updateUserRole } from '../controllers/adminController.js';
+import { getAllUsers, getAllBalances, updateUserRole, getAdminStatus } from '../controllers/adminController.js';
 
 const router = express.Router();
 
@@ -15,5 +15,8 @@ router.get('/balances', getAllBalances);
 
 // Update user role
 router.put('/users/:userId/role', updateUserRole);
+
+// Get current admin status
+router.get('/status', getAdminStatus);
 
 export default router; 

--- a/firestore.rules
+++ b/firestore.rules
@@ -74,6 +74,12 @@ service cloud.firestore {
       allow read: if true;
       allow write: if isAuthenticated();
     }
+
+    // Admins collection rules
+    match /admins/{adminId} {
+      allow read: if request.auth != null && request.auth.uid == adminId;
+      allow write: if isAdmin();
+    }
     
     // Balance collection rules
     match /balance/{userId} {

--- a/src/hooks/useAdminSession.ts
+++ b/src/hooks/useAdminSession.ts
@@ -53,7 +53,7 @@ export const useAdminSession = () => {
   }, [clearTimers, handleLogout]);
 
   const refreshSession = useCallback(async () => {
-    const admin = getCurrentAdmin();
+    const admin = await getCurrentAdmin();
     if (admin?.isAdmin) {
       try {
         // Refresh the Firebase token

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -17,8 +17,7 @@ import PrizeClaimsManager from './admin/PrizeClaimsManager';
 import QuestionPaperCategories from './admin/QuestionPaperCategories';
 import PaidContentManager from './admin/PaidContentManager';
 import { getAllUsers, getAllBalances } from '@/services/api/admin';
-import { db } from '@/services/firebase/config';
-import { doc, getDoc } from 'firebase/firestore';
+import { getCurrentAdmin } from '@/services/api/adminAuth';
 
 const Admin = () => {
   const { user } = useAuth();
@@ -33,17 +32,17 @@ const Admin = () => {
       return;
     }
 
-    // Check if user is admin in Firestore
+    // Check if user is admin via backend
     const checkAdminStatus = async () => {
       try {
-        const adminDoc = await getDoc(doc(db, 'admins', user.uid));
-        if (!adminDoc.exists() || !adminDoc.data()?.isAdmin) {
+        const admin = await getCurrentAdmin();
+        if (!admin?.isAdmin) {
           console.log('Admin page - User is not an admin. Redirecting to admin login');
           toast.error('Access denied. Admin privileges required.');
           navigate('/admin-auth');
           return;
         }
-        
+
         console.log('Admin page - Access granted');
         setLoading(false);
       } catch (error) {

--- a/src/pages/AdminAuth.tsx
+++ b/src/pages/AdminAuth.tsx
@@ -7,10 +7,13 @@ const AdminAuth = () => {
   const navigate = useNavigate();
   
   useEffect(() => {
-    const admin = getCurrentAdmin();
-    if (admin?.isAdmin) {
-      navigate('/admin');
-    }
+    const checkAdmin = async () => {
+      const admin = await getCurrentAdmin();
+      if (admin?.isAdmin) {
+        navigate('/admin');
+      }
+    };
+    checkAdmin();
   }, [navigate]);
   
   return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,6 +33,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { captureUserIP } from '../services/api/user';
 import { getDeviceId } from '../utils/deviceId';
+import { getCurrentAdmin } from '@/services/api/adminAuth';
 
 interface PaidContent {
   id: string;
@@ -149,8 +150,24 @@ const Home = () => {
     }
   };
 
-  const isAdmin = user && user.email && 
-    (['admin@example.com', 'ij@gmail.com', 'test@example.com', 'ww@gmail.com'].includes(user.email));
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const checkAdmin = async () => {
+      if (!user) {
+        setIsAdmin(false);
+        return;
+      }
+      try {
+        const admin = await getCurrentAdmin();
+        setIsAdmin(!!admin?.isAdmin);
+      } catch (error) {
+        console.error('Error checking admin status', error);
+        setIsAdmin(false);
+      }
+    };
+    checkAdmin();
+  }, [user]);
   
   const [isCustomAdmin, setIsCustomAdmin] = useState(false);
   


### PR DESCRIPTION
## Summary
- conditionally log auth messages only in development
- check admin status using Firestore instead of hard-coded emails
- await admin status checks when loading admin pages
- fix admin session refresh to await status
- restrict Firestore access to `admins` collection
- add backend endpoint for admin status verification
- use backend API in admin auth client
- check admin status via backend in admin dashboard

## Testing
- `npm run lint` *(fails: Unexpected any, react warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877c9d981b8832bb1c69300f7d8dceb