### PR TITLE
Use backend for admin auth

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { register, login, resetPassword, adminLogin } from '../controllers/authController.js';
+import { register, login, resetPassword, adminLogin, checkAdminSession } from '../controllers/authController.js';
 
 const router = express.Router();
 
@@ -7,5 +7,6 @@ router.post('/register', register);
 router.post('/login', login);
 router.post('/reset-password', resetPassword);
 router.post('/admin/login', adminLogin);
+router.get('/admin/check', checkAdminSession);
 
 export default router; 

--- a/src/services/api/admin.ts
+++ b/src/services/api/admin.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { getAuth } from 'firebase/auth';
 import { refreshAdminToken } from './adminAuth';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';

--- a/src/services/api/adminAuth.ts
+++ b/src/services/api/adminAuth.ts
@@ -1,113 +1,60 @@
-import { getAuth, signInWithEmailAndPassword, signOut } from 'firebase/auth';
-import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
-import { app, db } from '../firebase/config';
-import { toast } from 'sonner';
+import axios from 'axios';
+import { setCookie, getCookie, removeCookie } from '@/utils/cookies';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export interface AdminUser {
-  uid: string;
   email: string;
+  token: string;
   isAdmin: boolean;
 }
 
 export const loginAdmin = async (email: string, password: string): Promise<AdminUser> => {
-  try {
-    const auth = getAuth(app);
-    const userCredential = await signInWithEmailAndPassword(auth, email, password);
-    const user = userCredential.user;
+  const response = await axios.post(`${API_URL}/api/auth/admin/login`, { email, password });
+  const data = response.data;
 
-    // Check if the user is an admin in Firestore
-    const adminDoc = await getDoc(doc(db, 'admins', user.uid));
-    if (!adminDoc.exists() || !adminDoc.data()?.isAdmin) {
-      await signOut(auth);
-      throw new Error('You do not have admin privileges');
-    }
+  const adminInfo: AdminUser = {
+    email: data.email,
+    token: data.token,
+    isAdmin: true
+  };
 
-    // Update the user's role in the users collection
-    const userDoc = await getDoc(doc(db, 'users', user.uid));
-    if (userDoc.exists()) {
-      await updateDoc(doc(db, 'users', user.uid), {
-        role: 'admin'
-      });
-    } else {
-      await setDoc(doc(db, 'users', user.uid), {
-        email: user.email,
-        role: 'admin',
-        createdAt: new Date().toISOString()
-      });
-    }
-
-    return {
-      uid: user.uid,
-      email: user.email || '',
-      isAdmin: true
-    };
-  } catch (error: any) {
-    // Handle specific Firebase auth errors without logging to console
-    if (error.code === 'auth/invalid-credential') {
-      throw new Error('Invalid email or password');
-    } else if (error.code === 'auth/user-not-found') {
-      throw new Error('No admin account found with this email');
-    } else if (error.code === 'auth/wrong-password') {
-      throw new Error('Incorrect password');
-    } else if (error.code === 'auth/too-many-requests') {
-      throw new Error('Too many failed login attempts. Please try again later');
-    } else if (error.code === 'auth/user-disabled') {
-      throw new Error('This admin account has been disabled');
-    } else {
-      throw new Error('Failed to login as admin');
-    }
-  }
+  setCookie('adminAuth', JSON.stringify(adminInfo));
+  return adminInfo;
 };
 
 export const logoutAdmin = async (): Promise<void> => {
-  try {
-    const auth = getAuth(app);
-    await signOut(auth);
-  } catch (error) {
-    console.error('Admin logout error:', error);
-    throw new Error('Failed to logout');
-  }
+  removeCookie('adminAuth');
 };
 
-export const getCurrentAdmin = async (): Promise<AdminUser | null> => {
+export const getCurrentAdmin = (): AdminUser | null => {
+  const stored = getCookie('adminAuth');
+  if (!stored) return null;
   try {
-    const auth = getAuth(app);
-    const user = auth.currentUser;
-    
-    if (!user) {
-      return null;
-    }
-
-    // Check if the user is an admin in Firestore
-    const adminDoc = await getDoc(doc(db, 'admins', user.uid));
-    if (!adminDoc.exists() || !adminDoc.data()?.isAdmin) {
-      return null;
-    }
-
-    return {
-      uid: user.uid,
-      email: user.email || '',
-      isAdmin: true
-    };
-  } catch (error) {
-    console.error('Error getting current admin:', error);
+    return JSON.parse(stored) as AdminUser;
+  } catch {
     return null;
   }
 };
 
 export const refreshAdminToken = async (): Promise<string> => {
-  const auth = getAuth(app);
-  const user = auth.currentUser;
-  
-  if (!user) {
+  const admin = getCurrentAdmin();
+  if (!admin) {
     throw new Error('No authenticated admin user');
   }
-  
+  return admin.token;
+};
+
+export const checkAdminSession = async (): Promise<boolean> => {
+  const admin = getCurrentAdmin();
+  if (!admin) return false;
   try {
-    const token = await user.getIdToken(true); // Force refresh
-    return token;
-  } catch (error) {
-    console.error('Error refreshing admin token:', error);
-    throw new Error('Failed to refresh admin token');
+    await axios.get(`${API_URL}/api/auth/admin/check`, {
+      headers: { Authorization: `Bearer ${admin.token}` }
+    });
+    return true;
+  } catch {
+    removeCookie('adminAuth');
+    return false;
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- add `checkAdminSession` endpoint to verify admin token
- update auth routes to include the check API
- switch frontend admin auth to use backend token
- validate admin dashboard access via backend check

## Testing
- `npm run lint` *(fails: ESLint problems)*
- `cd backend && npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6877d6b511d8832ba8a28bc3a3205925