### PR TITLE
Secure admin auth via backend

### DIFF
--- a/src/hooks/useAdminSession.ts
+++ b/src/hooks/useAdminSession.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { getCurrentAdmin, refreshAdminToken, logoutAdmin } from '@/services/api/adminAuth';
+import { getCurrentAdmin, logoutAdmin } from '@/services/api/adminAuth';
 
 const ADMIN_SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 const SESSION_WARNING_TIME = 5 * 60 * 1000; // 5 minutes before timeout
@@ -55,15 +55,8 @@ export const useAdminSession = () => {
   const refreshSession = useCallback(async () => {
     const admin = getCurrentAdmin();
     if (admin?.isAdmin) {
-      try {
-        // Refresh the Firebase token
-        await refreshAdminToken();
-        resetSession();
-        return true;
-      } catch (error) {
-        console.error('Error refreshing session:', error);
-        return false;
-      }
+      resetSession();
+      return true;
     }
     return false;
   }, [resetSession]);

--- a/src/services/api/admin.ts
+++ b/src/services/api/admin.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import { getAuth } from 'firebase/auth';
 import { refreshAdminToken } from './adminAuth';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
@@ -106,7 +105,7 @@ export const getAllBalances = async (): Promise<UserBalance[]> => {
 export const updateUserRole = async (userId: string, role: 'user' | 'admin'): Promise<void> => {
   try {
     const api = await createApiInstance();
-    await api.patch(`/admin/users/${userId}/role`, { role });
+    await api.put(`/api/admin/users/${userId}/role`, { uid: userId, role });
   } catch (error: any) {
     console.error('Error updating user role:', error);
     if (error.response?.status === 403) {

--- a/src/services/api/adminAuth.ts
+++ b/src/services/api/adminAuth.ts
@@ -1,113 +1,44 @@
-import { getAuth, signInWithEmailAndPassword, signOut } from 'firebase/auth';
-import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
-import { app, db } from '../firebase/config';
-import { toast } from 'sonner';
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export interface AdminUser {
-  uid: string;
   email: string;
   isAdmin: boolean;
+  token: string;
 }
 
+const ADMIN_STORAGE_KEY = 'admin_session';
+
 export const loginAdmin = async (email: string, password: string): Promise<AdminUser> => {
-  try {
-    const auth = getAuth(app);
-    const userCredential = await signInWithEmailAndPassword(auth, email, password);
-    const user = userCredential.user;
-
-    // Check if the user is an admin in Firestore
-    const adminDoc = await getDoc(doc(db, 'admins', user.uid));
-    if (!adminDoc.exists() || !adminDoc.data()?.isAdmin) {
-      await signOut(auth);
-      throw new Error('You do not have admin privileges');
-    }
-
-    // Update the user's role in the users collection
-    const userDoc = await getDoc(doc(db, 'users', user.uid));
-    if (userDoc.exists()) {
-      await updateDoc(doc(db, 'users', user.uid), {
-        role: 'admin'
-      });
-    } else {
-      await setDoc(doc(db, 'users', user.uid), {
-        email: user.email,
-        role: 'admin',
-        createdAt: new Date().toISOString()
-      });
-    }
-
-    return {
-      uid: user.uid,
-      email: user.email || '',
-      isAdmin: true
-    };
-  } catch (error: any) {
-    // Handle specific Firebase auth errors without logging to console
-    if (error.code === 'auth/invalid-credential') {
-      throw new Error('Invalid email or password');
-    } else if (error.code === 'auth/user-not-found') {
-      throw new Error('No admin account found with this email');
-    } else if (error.code === 'auth/wrong-password') {
-      throw new Error('Incorrect password');
-    } else if (error.code === 'auth/too-many-requests') {
-      throw new Error('Too many failed login attempts. Please try again later');
-    } else if (error.code === 'auth/user-disabled') {
-      throw new Error('This admin account has been disabled');
-    } else {
-      throw new Error('Failed to login as admin');
-    }
-  }
+  const response = await axios.post(`${API_URL}/api/auth/admin/login`, { email, password });
+  const admin: AdminUser = {
+    email: response.data.email,
+    isAdmin: response.data.isAdmin,
+    token: response.data.token,
+  };
+  localStorage.setItem(ADMIN_STORAGE_KEY, JSON.stringify(admin));
+  return admin;
 };
 
 export const logoutAdmin = async (): Promise<void> => {
-  try {
-    const auth = getAuth(app);
-    await signOut(auth);
-  } catch (error) {
-    console.error('Admin logout error:', error);
-    throw new Error('Failed to logout');
-  }
+  localStorage.removeItem(ADMIN_STORAGE_KEY);
 };
 
-export const getCurrentAdmin = async (): Promise<AdminUser | null> => {
+export const getCurrentAdmin = (): AdminUser | null => {
+  const data = localStorage.getItem(ADMIN_STORAGE_KEY);
+  if (!data) return null;
   try {
-    const auth = getAuth(app);
-    const user = auth.currentUser;
-    
-    if (!user) {
-      return null;
-    }
-
-    // Check if the user is an admin in Firestore
-    const adminDoc = await getDoc(doc(db, 'admins', user.uid));
-    if (!adminDoc.exists() || !adminDoc.data()?.isAdmin) {
-      return null;
-    }
-
-    return {
-      uid: user.uid,
-      email: user.email || '',
-      isAdmin: true
-    };
-  } catch (error) {
-    console.error('Error getting current admin:', error);
+    return JSON.parse(data) as AdminUser;
+  } catch {
     return null;
   }
 };
 
 export const refreshAdminToken = async (): Promise<string> => {
-  const auth = getAuth(app);
-  const user = auth.currentUser;
-  
-  if (!user) {
+  const admin = getCurrentAdmin();
+  if (!admin) {
     throw new Error('No authenticated admin user');
   }
-  
-  try {
-    const token = await user.getIdToken(true); // Force refresh
-    return token;
-  } catch (error) {
-    console.error('Error refreshing admin token:', error);
-    throw new Error('Failed to refresh admin token');
-  }
-}; 
+  return admin.token;
+};


### PR DESCRIPTION
## Summary
- reimplement admin auth to use backend API instead of direct Firebase
- update admin API client accordingly
- simplify admin session management
- use backend token for admin dashboard access

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878ec4329f8832baf1357d85e4e0584