### PR TITLE
Add header ad management

### DIFF
--- a/backend/src/controllers/headerAdsController.ts
+++ b/backend/src/controllers/headerAdsController.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getHeaderAds = async (_req: Request, res: Response) => {
+  try {
+    const snapshot = await db.collection('headerAds').get();
+    const ads = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(ads);
+  } catch (error) {
+    console.error('Error fetching header ads:', error);
+    res.status(500).json({ error: 'Failed to fetch header ads' });
+  }
+};
+
+export const createHeaderAd = async (req: Request, res: Response) => {
+  try {
+    const data = req.body;
+    const docRef = await db.collection('headerAds').add({
+      ...data,
+      createdAt: new Date().toISOString()
+    });
+    res.json({ id: docRef.id, ...data });
+  } catch (error) {
+    console.error('Error creating header ad:', error);
+    res.status(500).json({ error: 'Failed to create header ad' });
+  }
+};
+
+export const updateHeaderAd = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const data = req.body;
+    await db.collection('headerAds').doc(id).update({
+      ...data,
+      updatedAt: new Date().toISOString()
+    });
+    res.json({ id, ...data });
+  } catch (error) {
+    console.error('Error updating header ad:', error);
+    res.status(500).json({ error: 'Failed to update header ad' });
+  }
+};
+
+export const deleteHeaderAd = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    await db.collection('headerAds').doc(id).delete();
+    res.json({ id });
+  } catch (error) {
+    console.error('Error deleting header ad:', error);
+    res.status(500).json({ error: 'Failed to delete header ad' });
+  }
+};

--- a/backend/src/routes/headerAdsRoutes.ts
+++ b/backend/src/routes/headerAdsRoutes.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import { getHeaderAds, createHeaderAd, updateHeaderAd, deleteHeaderAd } from '../controllers/headerAdsController.js';
+import { verifyFirebaseAdmin } from '../middleware/firebaseAdminAuth.js';
+
+const router = express.Router();
+
+router.get('/', getHeaderAds);
+router.post('/', verifyFirebaseAdmin, createHeaderAd);
+router.put('/:id', verifyFirebaseAdmin, updateHeaderAd);
+router.delete('/:id', verifyFirebaseAdmin, deleteHeaderAd);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import questionPaperRoutes from './questionPaperRoutes.js';
 import megaTestRoutes from './megaTestRoutes.js';
 import contentRoutes from './contentRoutes.js';
 import paidContentRoutes from './paidContentRoutes.js';
+import headerAdsRoutes from './headerAdsRoutes.js';
 
 const router = express.Router();
 
@@ -32,6 +33,7 @@ router.use('/mega-tests', megaTestRoutes);
 // Public content routes
 router.use('/content', contentRoutes);
 router.use('/paid-contents', paidContentRoutes);
+router.use('/header-ads', headerAdsRoutes);
 
 // Admin routes
 router.use('/admin', adminRoutes);

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../App';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Users, BookOpen, Wallet, Trophy, Gift, FileText, ScrollText, Info, Book, FileArchive, DollarSign } from 'lucide-react';
+import { Users, BookOpen, Wallet, Trophy, Gift, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Image } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { AdminHeader } from '@/components/admin/AdminHeader';
@@ -16,6 +16,7 @@ import MegaTestManager from './admin/MegaTestManager';
 import PrizeClaimsManager from './admin/PrizeClaimsManager';
 import QuestionPaperCategories from './admin/QuestionPaperCategories';
 import PaidContentManager from './admin/PaidContentManager';
+import HeaderAdsManager from './admin/HeaderAdsManager';
 import { getAllUsers, getAllBalances } from '@/services/api/admin';
 import { db } from '@/services/firebase/config';
 import { doc, getDoc } from 'firebase/firestore';
@@ -114,6 +115,10 @@ const Admin = () => {
               <DollarSign className="h-4 w-4" />
               <span>Paid Content</span>
             </TabsTrigger>
+            <TabsTrigger value="header-ads" className="flex items-center gap-2">
+              <Image className="h-4 w-4" />
+              <span>Header Ads</span>
+            </TabsTrigger>
             <TabsTrigger value="privacy-policy" className="flex items-center gap-2">
               <FileText className="h-4 w-4" />
               <span>Privacy Policy</span>
@@ -162,6 +167,10 @@ const Admin = () => {
 
           <TabsContent value="paid-content">
             <PaidContentManager />
+          </TabsContent>
+
+          <TabsContent value="header-ads">
+            <HeaderAdsManager />
           </TabsContent>
 
           <TabsContent value="privacy-policy">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,6 +29,7 @@ import {
 import { SessionTimer } from '../components/SessionTimer';
 import { useSessionTimeout } from '../hooks/useSessionTimeout';
 import { getPaidContents, purchaseContent, downloadContent } from '../services/api/paidContent';
+import { getHeaderAds, HeaderAd } from '../services/api/headerAds';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { captureUserIP } from '../services/api/user';
@@ -104,6 +105,11 @@ const Home = () => {
   const { data: paidContents, isLoading: isLoadingPaidContents } = useQuery<PaidContent[]>({
     queryKey: ['paid-contents'],
     queryFn: getPaidContents,
+  });
+
+  const { data: headerAds } = useQuery<HeaderAd[]>({
+    queryKey: ['header-ads'],
+    queryFn: getHeaderAds,
   });
 
   const registerMutation = useMutation({
@@ -440,6 +446,17 @@ const Home = () => {
             <ModeToggle />
           </div>
         </div>
+        {headerAds && headerAds.length > 0 && (
+          <div className="bg-muted border-t">
+            <div className="container flex overflow-x-auto gap-4 py-2">
+              {headerAds.map(ad => (
+                <a key={ad.id} href={ad.linkUrl || '#'} target="_blank" rel="noreferrer" className="flex-shrink-0">
+                  <img src={ad.imageUrl} alt={ad.text || 'Ad'} className="h-12 w-auto object-contain" />
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
       </header>
 
       <main className="container mx-auto px-4 py-3">

--- a/src/pages/admin/HeaderAdsManager.tsx
+++ b/src/pages/admin/HeaderAdsManager.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../../services/firebase/config';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { toast } from 'sonner';
+
+interface HeaderAd {
+  id: string;
+  imageUrl: string;
+  linkUrl?: string;
+  text?: string;
+}
+
+export default function HeaderAdsManager() {
+  const [ads, setAds] = useState<HeaderAd[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newAd, setNewAd] = useState({
+    linkUrl: '',
+    text: '',
+    imageFile: null as File | null,
+  });
+
+  useEffect(() => {
+    fetchAds();
+  }, []);
+
+  const fetchAds = async () => {
+    try {
+      const adsRef = collection(db, 'headerAds');
+      const snapshot = await getDocs(adsRef);
+      const adsList = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as HeaderAd[];
+      setAds(adsList);
+    } catch (error) {
+      console.error('Error fetching header ads:', error);
+      toast.error('Failed to load header ads');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setNewAd(prev => ({ ...prev, imageFile: file }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newAd.imageFile) {
+      toast.error('Please upload an image');
+      return;
+    }
+    try {
+      const imageRef = ref(storage, `header-ads/${Date.now()}_${newAd.imageFile.name}`);
+      await uploadBytes(imageRef, newAd.imageFile);
+      const imageUrl = await getDownloadURL(imageRef);
+      await addDoc(collection(db, 'headerAds'), {
+        imageUrl,
+        linkUrl: newAd.linkUrl || '',
+        text: newAd.text || '',
+        createdAt: new Date().toISOString(),
+      });
+      toast.success('Header ad added');
+      setNewAd({ linkUrl: '', text: '', imageFile: null });
+      fetchAds();
+    } catch (error) {
+      console.error('Error adding header ad:', error);
+      toast.error('Failed to add header ad');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this ad?')) return;
+    try {
+      await deleteDoc(doc(db, 'headerAds', id));
+      toast.success('Header ad deleted');
+      fetchAds();
+    } catch (error) {
+      console.error('Error deleting header ad:', error);
+      toast.error('Failed to delete header ad');
+    }
+  };
+
+  if (loading) {
+    return <div className="flex justify-center items-center min-h-screen">Loading...</div>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">Manage Header Ads</h1>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Add New Ad</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Image</label>
+              <Input type="file" accept="image/*" onChange={handleFileChange} required />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Link URL</label>
+              <Input value={newAd.linkUrl} onChange={e => setNewAd(prev => ({ ...prev, linkUrl: e.target.value }))} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Text</label>
+              <Input value={newAd.text} onChange={e => setNewAd(prev => ({ ...prev, text: e.target.value }))} />
+            </div>
+            <Button type="submit">Add Ad</Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {ads.map(ad => (
+          <Card key={ad.id}>
+            <CardHeader>
+              <CardTitle>Ad</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <img src={ad.imageUrl} alt="ad" className="w-full h-32 object-cover mb-4 rounded" />
+              {ad.text && <p className="mb-2">{ad.text}</p>}
+              {ad.linkUrl && (
+                <a href={ad.linkUrl} target="_blank" rel="noreferrer" className="text-blue-500">
+                  {ad.linkUrl}
+                </a>
+              )}
+              <Button variant="destructive" className="mt-4" onClick={() => handleDelete(ad.id)}>
+                Delete
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/services/api/headerAds.ts
+++ b/src/services/api/headerAds.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { getOptionalAuthToken } from './auth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface HeaderAd {
+  id: string;
+  imageUrl: string;
+  linkUrl?: string;
+  text?: string;
+}
+
+export const getHeaderAds = async (): Promise<HeaderAd[]> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.get(`${API_URL}/api/header-ads`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+  return res.data;
+};
+
+export const createHeaderAd = async (data: Omit<HeaderAd, 'id'>): Promise<HeaderAd> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.post(`${API_URL}/api/header-ads`, data, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+  return res.data;
+};
+
+export const updateHeaderAd = async (id: string, data: Partial<Omit<HeaderAd, 'id'>>): Promise<HeaderAd> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.put(`${API_URL}/api/header-ads/${id}`, data, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+  return res.data;
+};
+
+export const deleteHeaderAd = async (id: string): Promise<void> => {
+  const token = await getOptionalAuthToken();
+  await axios.delete(`${API_URL}/api/header-ads/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+};


### PR DESCRIPTION
## Summary
- create header ads controller and routes on backend
- expose header ads routes in API router
- add API client for header ads
- create admin UI for managing header ads
- display header ads on the home page

## Testing
- `npm run lint` *(fails: 99 errors)*
- `npm --prefix backend run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687904f68d1c832ba33ab1e54d0a930e