### PR TITLE
Add server-side time tracking for Mega Tests

### DIFF
--- a/backend/src/routes/megaTestRoutes.ts
+++ b/backend/src/routes/megaTestRoutes.ts
@@ -9,7 +9,8 @@ import {
   hasUserSubmittedMegaTest,
   getMegaTestById,
   getMegaTestPrizes,
-  submitMegaTestResult
+  submitMegaTestResult,
+  startMegaTest
 } from '../controllers/megaTestController.js';
 
 const router = express.Router();
@@ -23,6 +24,7 @@ router.use(authenticateUser);
 router.post('/:megaTestId/register', registerForMegaTest);
 router.get('/:megaTestId/registration-status/:userId', isUserRegistered);
 router.get('/:megaTestId/submission-status/:userId', hasUserSubmittedMegaTest);
+router.post('/:megaTestId/start', startMegaTest);
 router.post('/:megaTestId/submit', submitMegaTestResult);
 router.post('/:megaTestId/prize-claims', submitPrizeClaim);
 

--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Loader2, ChevronRight, ChevronLeft, Clock, CreditCard, Troph
 import {
   getMegaTestById,
   submitMegaTestResult,
+  startMegaTest,
   MegaTestQuestion,
   hasUserSubmittedMegaTest
 } from '@/services/api/megaTest';
@@ -216,13 +217,18 @@ const MegaTest = () => {
     }
   };
 
-  const startQuiz = () => {
+  const startQuiz = async () => {
     if (isQuizStarted) {
       toast.error('You have already started this quiz');
       return;
     }
     setIsQuizStarted(true);
     setStartTime(Date.now());
+    try {
+      await startMegaTest(megaTestId!);
+    } catch (error) {
+      toast.error('Failed to record start time');
+    }
   };
 
   // Add this new function to calculate the actual time limit

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -123,6 +123,15 @@ export const hasUserSubmittedMegaTest = async (
   return res.data.submitted;
 };
 
+export const startMegaTest = async (megaTestId: string): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/mega-tests/${megaTestId}/start`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+};
+
 export const getMegaTestById = async (
   megaTestId: string
 ): Promise<{ megaTest: MegaTest; questions: MegaTestQuestion[] }> => {


### PR DESCRIPTION
## Summary
- ensure server records start time of a Mega Test
- compute completion time on the server instead of trusting the client
- expose new `/start` API endpoint
- call the new endpoint from the frontend when starting a Mega Test

## Testing
- `npm run lint` *(fails: 100 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687919a2d0bc832b949e841d864b16d5