### PR TITLE
Fix participant date display

### DIFF
--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -1508,7 +1508,14 @@ const MegaTestManager = () => {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{participant.username}</td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{participant.email}</td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {participant.registeredAt ? format(participant.registeredAt.toDate(), 'MMM d, yyyy h:mm a') : 'N/A'}
+                          {participant.registeredAt
+                            ? format(
+                                typeof participant.registeredAt.toDate === 'function'
+                                  ? participant.registeredAt.toDate()
+                                  : new Date(participant.registeredAt),
+                                'MMM d, yyyy h:mm a'
+                              )
+                            : 'N/A'}
                         </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 flex items-center gap-1">
                               {participant.ipAddress}


### PR DESCRIPTION
## Summary
- avoid calling `toDate` on non-Timestamp objects when listing Mega Test participants

## Testing
- `npm run lint` *(fails: 121 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687a61142e3c832ba5f12dc246eebe54