### PR TITLE
Fix withdrawal deletion logic

### DIFF
--- a/src/services/api/withdrawal.ts
+++ b/src/services/api/withdrawal.ts
@@ -14,6 +14,8 @@ export interface WithdrawalRequest {
   requestDate: string;
   completionDate?: string;
   notes?: string;
+  userExpiryDate?: string;
+  deletedForAdmin?: boolean;
 }
 
 export const MINIMUM_WITHDRAWAL_AMOUNT = 50;


### PR DESCRIPTION
## Summary
- keep processed withdrawals visible to users for three days
- hide processed withdrawals from admin view instead of deleting them
- auto-clean expired withdrawal records when users fetch history
- add new fields in API models

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a72435798832ba35279631219c377