### PR TITLE
Add daily challenge backend

### DIFF
--- a/backend/src/routes/dailyChallengeRoutes.ts
+++ b/backend/src/routes/dailyChallengeRoutes.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { authenticateUser } from '../middleware/auth.js';
+import { verifyFirebaseAdmin } from '../middleware/firebaseAdminAuth.js';
+import {
+  createChallenge,
+  addQuestion,
+  getDailyChallenges,
+  startChallenge,
+  getChallengeStatus,
+  getNextQuestion,
+  submitAnswer,
+} from '../controllers/challengeController.js';
+
+const router = express.Router();
+
+// Public list of active challenges
+router.get('/', getDailyChallenges);
+
+// Authenticated user actions
+router.use(authenticateUser);
+router.post('/:challengeId/start', startChallenge);
+router.get('/:challengeId/status', getChallengeStatus);
+router.get('/:challengeId/question', getNextQuestion);
+router.post('/:challengeId/answer', submitAnswer);
+
+// Admin actions
+router.use(verifyFirebaseAdmin);
+router.post('/', createChallenge);
+router.post('/:challengeId/questions', addQuestion);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import questionPaperRoutes from './questionPaperRoutes.js';
 import megaTestRoutes from './megaTestRoutes.js';
 import contentRoutes from './contentRoutes.js';
 import paidContentRoutes from './paidContentRoutes.js';
+import dailyChallengeRoutes from './dailyChallengeRoutes.js';
 import withdrawalRoutes from './withdrawalRoutes.js';
 
 const router = express.Router();
@@ -34,6 +35,9 @@ router.use('/mega-tests', megaTestRoutes);
 router.use('/content', contentRoutes);
 router.use('/paid-contents', paidContentRoutes);
 
+// Daily challenge routes
+router.use('/daily-challenges', dailyChallengeRoutes);
+
 // Withdrawal routes
 router.use('/withdrawals', withdrawalRoutes);
 
@@ -43,4 +47,6 @@ router.use('/admin', adminRoutes);
 // Health check route
 router.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
-});export default router; 
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- implement backend support for Daily Challenge gameplay
- expose new daily challenge routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `cd backend && npm run lint` *(fails: invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_687a7cbe1448832ba0d3b3ca1ffbb046