### PR TITLE
Add daily challenge UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,8 @@ import ProtectedRoute from './components/ProtectedRoute';
 const QuizCategories = React.lazy(() => import('./pages/QuizCategories'));
 const SubCategories = React.lazy(() => import('./pages/SubCategories'));
 const AllMegaTests = React.lazy(() => import('./pages/AllMegaTests'));
+const DailyChallenges = React.lazy(() => import('./pages/DailyChallenges'));
+const DailyChallengePlay = React.lazy(() => import('./pages/DailyChallengePlay'));
 
 interface AuthContextProps {
   user: User | null;
@@ -84,6 +86,8 @@ const AppContent: React.FC = () => {
       <Route path="/auth" element={<Auth />} />
       <Route path="/" element={<Home />} />
       <Route path="/all-mega-tests" element={<AllMegaTests />} />
+      <Route path="/daily-challenges" element={<DailyChallenges />} />
+      <Route path="/daily-challenges/:challengeId" element={<DailyChallengePlay />} />
       <Route path="/profile" element={
         <ProtectedRoute>
           <Profile />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../App';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign } from 'lucide-react';
+import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Flame } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { AdminHeader } from '@/components/admin/AdminHeader';
@@ -15,6 +15,7 @@ import GuideManager from '../components/admin/GuideManager';
 import MegaTestManager from './admin/MegaTestManager';
 import QuestionPaperCategories from './admin/QuestionPaperCategories';
 import PaidContentManager from './admin/PaidContentManager';
+import DailyChallengeManager from './admin/DailyChallengeManager';
 import { WithdrawalManagement } from '../components/admin/WithdrawalManagement';
 import { getAllUsers, getAllBalances } from '@/services/api/admin';
 import { db } from '@/services/firebase/config';
@@ -102,6 +103,10 @@ const Admin = () => {
               <Trophy className="h-4 w-4" />
               <span>Mega Tests</span>
             </TabsTrigger>
+            <TabsTrigger value="daily-challenges" className="flex items-center gap-2">
+              <Flame className="h-4 w-4" />
+              <span>Daily Challenges</span>
+            </TabsTrigger>
             <TabsTrigger value="question-papers" className="flex items-center gap-2">
               <FileArchive className="h-4 w-4" />
               <span>Question Papers</span>
@@ -152,6 +157,9 @@ const Admin = () => {
             <MegaTestManager />
           </TabsContent>
 
+          <TabsContent value="daily-challenges">
+            <DailyChallengeManager />
+          </TabsContent>
 
           <TabsContent value="question-papers">
             <QuestionPaperCategories />

--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { getChallengeStatus, getNextQuestion, submitAnswer, ChallengeQuestion } from '@/services/api/dailyChallenge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+
+const DailyChallengePlay = () => {
+  const { challengeId } = useParams<{ challengeId: string }>();
+  const [status, setStatus] = useState<any>(null);
+  const [question, setQuestion] = useState<ChallengeQuestion | null>(null);
+  const [selected, setSelected] = useState('');
+
+  const fetchNext = async () => {
+    if (!challengeId) return;
+    try {
+      const q = await getNextQuestion(challengeId);
+      setQuestion(q);
+      setSelected('');
+    } catch (e: any) {
+      toast.error(e.response?.data?.error || 'Failed to get question');
+    }
+  };
+
+  useEffect(() => {
+    if (!challengeId) return;
+    getChallengeStatus(challengeId)
+      .then(setStatus)
+      .then(() => fetchNext())
+      .catch(err => toast.error(err.response?.data?.error || 'Failed to load'));
+  }, [challengeId]);
+
+  const submitMutation = useMutation({
+    mutationFn: (answer: string) => submitAnswer(challengeId!, question!.id, answer),
+    onSuccess: data => {
+      setStatus(data);
+      if (data.completed) {
+        toast.success(data.won ? 'You won!' : 'Challenge over');
+      } else {
+        fetchNext();
+      }
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.error || 'Failed');
+    },
+  });
+
+  if (!challengeId) return <p>Invalid challenge</p>;
+
+  if (status && status.completed) {
+    return (
+      <div className="container mx-auto p-4 max-w-xl text-center">
+        <h1 className="text-2xl font-bold mb-4">Challenge Result</h1>
+        <p className="mb-2">Correct: {status.correctCount}</p>
+        <p className="mb-2">Attempts: {status.attemptCount}</p>
+        <p className="mb-6 font-semibold">{status.won ? 'You won!' : 'Better luck next time.'}</p>
+        <Link to="/daily-challenges" className="text-blue-500">Back to Challenges</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4 max-w-xl">
+      {question ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{question.text}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RadioGroup value={selected} onValueChange={setSelected} className="space-y-2">
+              {question.options.map(opt => (
+                <div key={opt} className="flex items-center space-x-2">
+                  <RadioGroupItem value={opt} id={opt} />
+                  <Label htmlFor={opt}>{opt}</Label>
+                </div>
+              ))}
+            </RadioGroup>
+            <Button className="mt-4" disabled={!selected || submitMutation.isPending} onClick={() => submitMutation.mutate(selected)}>
+              Submit
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <p>Loading...</p>
+      )}
+      <div className="mt-4 text-sm text-muted-foreground">
+        Correct: {status?.correctCount || 0} / Attempts: {status?.attemptCount || 0}
+      </div>
+      <div className="mt-4">
+        <Link to="/daily-challenges" className="text-blue-500">Back to Challenges</Link>
+      </div>
+    </div>
+  );
+};
+
+export default DailyChallengePlay;

--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getDailyChallenges, startChallenge, DailyChallenge, getChallengeStatus } from '@/services/api/dailyChallenge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/App';
+import { toast } from 'sonner';
+
+const DailyChallenges = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const { data: challenges, refetch } = useQuery({
+    queryKey: ['daily-challenges'],
+    queryFn: getDailyChallenges,
+  });
+
+  const startMutation = useMutation({
+    mutationFn: (id: string) => startChallenge(id),
+    onSuccess: (_data, id) => {
+      toast.success('Challenge started');
+      navigate(`/daily-challenges/${id}`);
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.error || 'Failed to start');
+    },
+  });
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  const handleStart = async (challenge: DailyChallenge) => {
+    if (!user) {
+      toast.error('Please login first');
+      return;
+    }
+    try {
+      const status = await getChallengeStatus(challenge.id).catch(() => null);
+      if (!status) {
+        await startMutation.mutateAsync(challenge.id);
+      } else {
+        navigate(`/daily-challenges/${challenge.id}`);
+      }
+    } catch (error: any) {
+      toast.error(error.response?.data?.error || 'Error starting');
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4 max-w-3xl">
+      <h1 className="text-3xl font-bold mb-6">Daily Challenges</h1>
+      <div className="grid gap-4">
+        {challenges?.map(ch => (
+          <Card key={ch.id} className="hover:shadow-lg transition-shadow">
+            <CardHeader>
+              <CardTitle>{ch.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Reward: ₹{ch.reward}</p>
+                <p className="text-sm text-muted-foreground">Required Correct: {ch.requiredCorrect}</p>
+              </div>
+              <Button onClick={() => handleStart(ch)}>Start</Button>
+            </CardContent>
+          </Card>
+        ))}
+        {challenges && challenges.length === 0 && (
+          <p>No challenges available.</p>
+        )}
+      </div>
+      <div className="mt-4">
+        <Link to="/">← Back to Home</Link>
+      </div>
+    </div>
+  );
+};
+
+export default DailyChallenges;

--- a/src/pages/admin/DailyChallengeManager.tsx
+++ b/src/pages/admin/DailyChallengeManager.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { adminCreateChallenge, adminAddQuestion, getDailyChallenges } from '@/services/api/dailyChallenge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { SanitizedInput } from '@/components/ui/sanitized-input';
+import { SanitizedTextarea } from '@/components/ui/sanitized-textarea';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+
+const DailyChallengeManager = () => {
+  const queryClient = useQueryClient();
+  const { data: challenges } = useQuery({
+    queryKey: ['daily-challenges-admin'],
+    queryFn: getDailyChallenges,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: ({ title, reward, requiredCorrect }: { title: string; reward: number; requiredCorrect: number }) =>
+      adminCreateChallenge(title, reward, requiredCorrect),
+    onSuccess: () => {
+      toast.success('Challenge created');
+      queryClient.invalidateQueries({ queryKey: ['daily-challenges-admin'] });
+    },
+    onError: (err: any) => toast.error(err.response?.data?.error || 'Failed'),
+  });
+
+  const questionMutation = useMutation({
+    mutationFn: ({ cid, text, options, correct }: { cid: string; text: string; options: string[]; correct: string }) =>
+      adminAddQuestion(cid, text, options, correct),
+    onSuccess: () => {
+      toast.success('Question added');
+    },
+    onError: (err: any) => toast.error(err.response?.data?.error || 'Failed'),
+  });
+
+  const [createForm, setCreateForm] = useState({ title: '', reward: '', requiredCorrect: '' });
+  const [questionForm, setQuestionForm] = useState({ text: '', a: '', b: '', c: '', d: '', correct: 'a' });
+  const [activeChallenge, setActiveChallenge] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button>Create Challenge</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Challenge</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Title</Label>
+              <SanitizedInput value={createForm.title} onChange={v => setCreateForm(f => ({ ...f, title: v }))} />
+            </div>
+            <div>
+              <Label>Reward</Label>
+              <SanitizedInput value={createForm.reward} onChange={v => setCreateForm(f => ({ ...f, reward: v }))} type="number" />
+            </div>
+            <div>
+              <Label>Required Correct</Label>
+              <SanitizedInput value={createForm.requiredCorrect} onChange={v => setCreateForm(f => ({ ...f, requiredCorrect: v }))} type="number" />
+            </div>
+            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect) })}>Create</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <h2 className="text-xl font-semibold">Existing Challenges</h2>
+      <div className="grid gap-4">
+        {challenges?.map(ch => (
+          <Card key={ch.id}>
+            <CardHeader>
+              <CardTitle>{ch.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm mb-2">Reward: ₹{ch.reward}</p>
+              <Button size="sm" onClick={() => setActiveChallenge(ch.id)}>Add Question</Button>
+            </CardContent>
+          </Card>
+        ))}
+        {challenges && challenges.length === 0 && <p>No challenges</p>}
+      </div>
+
+      <Dialog open={!!activeChallenge} onOpenChange={() => setActiveChallenge(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Question</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Question Text</Label>
+              <SanitizedTextarea value={questionForm.text} onChange={v => setQuestionForm(f => ({ ...f, text: v }))} />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <SanitizedInput placeholder="Option A" value={questionForm.a} onChange={v => setQuestionForm(f => ({ ...f, a: v }))} />
+              <SanitizedInput placeholder="Option B" value={questionForm.b} onChange={v => setQuestionForm(f => ({ ...f, b: v }))} />
+              <SanitizedInput placeholder="Option C" value={questionForm.c} onChange={v => setQuestionForm(f => ({ ...f, c: v }))} />
+              <SanitizedInput placeholder="Option D" value={questionForm.d} onChange={v => setQuestionForm(f => ({ ...f, d: v }))} />
+            </div>
+            <div>
+              <Label>Correct Option</Label>
+              <SanitizedInput value={questionForm.correct} onChange={v => setQuestionForm(f => ({ ...f, correct: v }))} />
+            </div>
+            <Button onClick={() => {
+              if (!activeChallenge) return;
+              questionMutation.mutate({
+                cid: activeChallenge,
+                text: questionForm.text,
+                options: [questionForm.a, questionForm.b, questionForm.c, questionForm.d],
+                correct: questionForm.correct,
+              });
+              setQuestionForm({ text: '', a: '', b: '', c: '', d: '', correct: 'a' });
+            }}>Add</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default DailyChallengeManager;

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -1,0 +1,123 @@
+import axios from 'axios';
+import { getAuthToken, getOptionalAuthToken } from './auth';
+import { refreshAdminToken } from './adminAuth';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface DailyChallenge {
+  id: string;
+  title: string;
+  reward: number;
+  requiredCorrect: number;
+  maxAttempts?: number;
+  active: boolean;
+}
+
+export interface ChallengeStatus {
+  userId: string;
+  challengeId: string;
+  date: string;
+  correctCount: number;
+  attemptCount: number;
+  attemptedQuestions: string[];
+  completed: boolean;
+  won: boolean;
+  startedAt: string;
+  completedAt?: string;
+}
+
+export interface ChallengeQuestion {
+  id: string;
+  text: string;
+  options: string[];
+}
+
+export const getDailyChallenges = async (): Promise<DailyChallenge[]> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.get(`${API_URL}/api/daily-challenges`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  return res.data;
+};
+
+export const startChallenge = async (challengeId: string): Promise<void> => {
+  const token = await getAuthToken();
+  await axios.post(
+    `${API_URL}/api/daily-challenges/${challengeId}/start`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+};
+
+export const getChallengeStatus = async (
+  challengeId: string,
+): Promise<ChallengeStatus> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/daily-challenges/${challengeId}/status`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return res.data;
+};
+
+export const getNextQuestion = async (
+  challengeId: string,
+): Promise<ChallengeQuestion> => {
+  const token = await getAuthToken();
+  const res = await axios.get(
+    `${API_URL}/api/daily-challenges/${challengeId}/question`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return res.data;
+};
+
+export const submitAnswer = async (
+  challengeId: string,
+  questionId: string,
+  answer: string,
+): Promise<ChallengeStatus & { correct: boolean }> => {
+  const token = await getAuthToken();
+  const res = await axios.post(
+    `${API_URL}/api/daily-challenges/${challengeId}/answer`,
+    { questionId, answer },
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return res.data;
+};
+
+// --- Admin APIs ---
+const createAdminApi = async () => {
+  const token = await refreshAdminToken();
+  return axios.create({
+    baseURL: API_URL,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+};
+
+export const adminCreateChallenge = async (
+  title: string,
+  reward: number,
+  requiredCorrect: number,
+): Promise<string> => {
+  const api = await createAdminApi();
+  const res = await api.post('/api/daily-challenges', {
+    title,
+    reward,
+    requiredCorrect,
+  });
+  return res.data.id;
+};
+
+export const adminAddQuestion = async (
+  challengeId: string,
+  text: string,
+  options: string[],
+  correctAnswer: string,
+): Promise<void> => {
+  const api = await createAdminApi();
+  await api.post(`/api/daily-challenges/${challengeId}/questions`, {
+    text,
+    options,
+    correctAnswer,
+  });
+};


### PR DESCRIPTION
## Summary
- implement API helpers for daily challenge endpoints
- add user pages for listing challenges and playing them
- add admin manager UI with create challenge and add question
- wire up routes and admin tabs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2c89f4c4832baae500947b8d2846