### PR TITLE
Improve daily challenge UX

### DIFF
--- a/backend/src/routes/dailyChallengeRoutes.ts
+++ b/backend/src/routes/dailyChallengeRoutes.ts
@@ -6,6 +6,10 @@ import {
   addQuestion,
   addBulkQuestions,
   getQuestions,
+  updateQuestion,
+  deleteQuestion,
+  deleteChallenge,
+  getQuestionCount,
   getDailyChallenges,
   startChallenge,
   getChallengeStatus,
@@ -31,5 +35,9 @@ router.post('/', createChallenge);
 router.post('/:challengeId/questions', addQuestion);
 router.post('/:challengeId/questions/bulk', addBulkQuestions);
 router.get('/:challengeId/questions', getQuestions);
+router.get('/:challengeId/questions/count', getQuestionCount);
+router.put('/:challengeId/questions/:questionId', updateQuestion);
+router.delete('/:challengeId/questions/:questionId', deleteQuestion);
+router.delete('/:challengeId', deleteChallenge);
 
 export default router;

--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -61,6 +61,7 @@ const DailyChallenges = () => {
               <div>
                 <p className="text-sm text-muted-foreground">Reward: ₹{ch.reward}</p>
                 <p className="text-sm text-muted-foreground">Required Correct: {ch.requiredCorrect}</p>
+                <p className="text-sm text-muted-foreground">Time Limit: {ch.timeLimit}s</p>
               </div>
               <Button onClick={() => handleStart(ch)}>Start</Button>
             </CardContent>

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -9,7 +9,7 @@ export interface DailyChallenge {
   title: string;
   reward: number;
   requiredCorrect: number;
-  maxAttempts?: number;
+  timeLimit: number;
   active: boolean;
 }
 
@@ -18,12 +18,12 @@ export interface ChallengeStatus {
   challengeId: string;
   date: string;
   correctCount: number;
-  attemptCount: number;
   attemptedQuestions: string[];
   completed: boolean;
   won: boolean;
   startedAt: string;
   completedAt?: string;
+  timeLimit: number;
 }
 
 export interface ChallengeQuestion {
@@ -98,12 +98,14 @@ export const adminCreateChallenge = async (
   title: string,
   reward: number,
   requiredCorrect: number,
+  timeLimit: number,
 ): Promise<string> => {
   const api = await createAdminApi();
   const res = await api.post('/api/daily-challenges', {
     title,
     reward,
     requiredCorrect,
+    timeLimit,
   });
   return res.data.id;
 };
@@ -127,6 +129,40 @@ export const adminAddBulkQuestions = async (
 ): Promise<void> => {
   const api = await createAdminApi();
   await api.post(`/api/daily-challenges/${challengeId}/questions/bulk`, { questions });
+};
+
+export const adminUpdateQuestion = async (
+  challengeId: string,
+  questionId: string,
+  text: string,
+  options: string[],
+  correctAnswer: string,
+): Promise<void> => {
+  const api = await createAdminApi();
+  await api.put(`/api/daily-challenges/${challengeId}/questions/${questionId}`, {
+    text,
+    options,
+    correctAnswer,
+  });
+};
+
+export const adminDeleteQuestion = async (
+  challengeId: string,
+  questionId: string,
+): Promise<void> => {
+  const api = await createAdminApi();
+  await api.delete(`/api/daily-challenges/${challengeId}/questions/${questionId}`);
+};
+
+export const adminDeleteChallenge = async (challengeId: string): Promise<void> => {
+  const api = await createAdminApi();
+  await api.delete(`/api/daily-challenges/${challengeId}`);
+};
+
+export const adminGetQuestionCount = async (challengeId: string): Promise<number> => {
+  const api = await createAdminApi();
+  const res = await api.get(`/api/daily-challenges/${challengeId}/questions/count`);
+  return res.data.count;
 };
 
 export const adminGetQuestions = async (


### PR DESCRIPTION
## Summary
- allow admins to manage daily challenges better
- show challenge progress and timer controls
- start challenges correctly from home page
- display timer and improved layout when playing

## Testing
- `npm run build` *(fails: vite not found before install; ran after npm install)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b388f5100832bb89ee02a146b383c