### PR TITLE
Fix daily challenge buttons and quiz options

### DIFF
--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -90,12 +90,18 @@ const DailyChallengePlay = () => {
               </div>
             )}
             <RadioGroup value={selected} onValueChange={setSelected} className="space-y-2">
-              {question.options.map(opt => (
-                <div key={opt} className="flex items-center space-x-2">
-                  <RadioGroupItem value={opt} id={opt} />
-                  <Label htmlFor={opt}>{opt}</Label>
-                </div>
-              ))}
+              {question.options
+                .filter(opt => opt && opt.trim())
+                .slice(0, 4)
+                .map((opt, idx) => {
+                  const optionId = `${question.id}-${idx}`;
+                  return (
+                    <div key={optionId} className="flex items-center space-x-2">
+                      <RadioGroupItem value={opt} id={optionId} />
+                      <Label htmlFor={optionId}>{opt}</Label>
+                    </div>
+                  );
+                })}
             </RadioGroup>
             <Button className="mt-4" disabled={!selected || submitMutation.isPending || timeLeft === 0} onClick={() => submitMutation.mutate(selected)}>
               Submit


### PR DESCRIPTION
## Summary
- show "Already Played" after a challenge is attempted
- disable the start button once a user has played
- filter and limit options in daily challenge quiz and give unique ids

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b3d344e60832ba47cc54351c72343