### PR TITLE
Fix timer reset on daily challenge

### DIFF
--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -56,7 +56,11 @@ const DailyChallengePlay = () => {
   const submitMutation = useMutation({
     mutationFn: (answer: string) => submitAnswer(challengeId!, question!.id, answer),
     onSuccess: data => {
-      setStatus(data);
+      // merge with existing status so startedAt is preserved for timer
+      setStatus(prev => ({
+        ...(prev || {}),
+        ...data,
+      }));
       if (data.completed) {
         toast.success(data.won ? 'You won!' : 'Challenge over');
       } else {


### PR DESCRIPTION
## Summary
- keep existing challenge status fields when submitting an answer so that the timer does not lose its start time

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b4fd10754832bbcc89bb2992ae127