### PR TITLE
Fix result page loading flicker

### DIFF
--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -28,10 +28,18 @@ const DailyChallengePlay = () => {
 
   useEffect(() => {
     if (!challengeId) return;
-    getChallengeStatus(challengeId)
-      .then(setStatus)
-      .then(() => fetchNext())
-      .catch(err => toast.error(err.response?.data?.error || 'Failed to load'));
+    const loadStatusAndQuestion = async () => {
+      try {
+        const statusData = await getChallengeStatus(challengeId);
+        setStatus(statusData);
+        if (!statusData.completed) {
+          await fetchNext();
+        }
+      } catch (err: any) {
+        toast.error(err.response?.data?.error || 'Failed to load');
+      }
+    };
+    loadStatusAndQuestion();
   }, [challengeId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid requesting next question when challenge already complete

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b542555b0832bb44c187c0775068f