### PR TITLE
Fix trophy icon reference

### DIFF
--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { getDailyChallenges, startChallenge, DailyChallenge, getChallengeStatus } from '@/services/api/dailyChallenge';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Trophy, ListChecks, Clock } from 'lucide-react';
 import { useAuth } from '@/App';
 import { toast } from 'sonner';
 


### PR DESCRIPTION
## Summary
- import Trophy, ListChecks and Clock icons in DailyChallenges

## Testing
- `npm run lint` *(fails: Unexpected any type in project)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b66c70f50832bb05c4674d5c1a037