### PR TITLE
Fix blog navigation loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,12 +39,6 @@ const AllMegaTests = React.lazy(() => import('./pages/AllMegaTests'));
 const DailyChallenges = React.lazy(() => import('./pages/DailyChallenges'));
 const DailyChallengePlay = React.lazy(() => import('./pages/DailyChallengePlay'));
 
-const BlogRedirect: React.FC = () => {
-  useEffect(() => {
-    window.location.href = '/blog/';
-  }, []);
-  return <div>Redirecting to blog...</div>;
-};
 
 interface AuthContextProps {
   user: User | null;
@@ -172,7 +166,6 @@ const AppContent: React.FC = () => {
           <PaidContentManager />
         </ProtectedRoute>
       } />
-      <Route path="/blog/*" element={<BlogRedirect />} />
     </Routes>
     </Suspense>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -891,12 +891,12 @@ const Home = () => {
               About Us
             </Link>
             <span className="hidden sm:inline text-sm">•</span>
-            <Link
-              to="/blog"
+            <a
+              href="/blog/"
               className="text-sm hover:text-foreground transition-colors"
             >
               Blog
-            </Link>
+            </a>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- remove `<BlogRedirect>` and its route
- open `/blog/` via a regular anchor tag instead of React Router `Link`

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_687bb327a1f0832b871518f97739bc81