### PR TITLE
Fix blog link

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -892,8 +892,10 @@ const Home = () => {
             </Link>
             <span className="hidden sm:inline text-sm">•</span>
             <a
-              href="/blog/"
+              href="https://rajtest.com/blog/"
               className="text-sm hover:text-foreground transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Blog
             </a>


### PR DESCRIPTION
## Summary
- open the blog in a new tab via external URL

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687bb51ab4e4832b8bb9b2f64b1aad69