### PR TITLE
Fix blog link for local dev

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -892,7 +892,7 @@ const Home = () => {
             </Link>
             <span className="hidden sm:inline text-sm">•</span>
             <a
-              href="/blog/"
+              href={import.meta.env.DEV ? 'http://localhost:3000/' : '/blog/'}
               className="text-sm hover:text-foreground transition-colors"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- adjust Blog footer link to open local Next.js dev server when running in development

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bbd6a3bb0832ba54e9b6837b9ce84