### PR TITLE
Fix Blog ESM warning

### DIFF
--- a/blog/package.json
+++ b/blog/package.json
@@ -21,5 +21,6 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.3"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
## Summary
- mark `blog` package as an ES module

## Testing
- `npm run dev` in `blog`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bc4484a60832b83e2fc33d75f83c7