### PR TITLE
Enhance daily challenge management

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -34,11 +34,12 @@ const checkTimeLimitAndUpdate = async (
 
 export const createChallenge = async (req: Request, res: Response) => {
   try {
-    const { title, reward, requiredCorrect, timeLimit } = req.body as {
+    const { title, reward, requiredCorrect, timeLimit, description } = req.body as {
       title: string;
       reward: number;
       requiredCorrect: number;
       timeLimit: number;
+      description?: string;
     };
     if (!title || !reward || !requiredCorrect || !timeLimit) {
       return res.status(400).json({ error: 'Missing fields' });
@@ -48,6 +49,7 @@ export const createChallenge = async (req: Request, res: Response) => {
       reward,
       requiredCorrect,
       timeLimit,
+      description: description || '',
       active: true,
       createdAt: new Date().toISOString(),
     });

--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -82,11 +82,14 @@ const DailyChallenges = () => {
             key={ch.id}
             className="relative overflow-hidden border-2 border-purple-200 hover:border-purple-400 bg-gradient-to-br from-white via-purple-50 to-blue-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 transition-all duration-300 hover:shadow-xl"
           >
-            <CardHeader className="pb-2">
-              <CardTitle className="text-lg font-semibold text-purple-700 dark:text-purple-400">
-                {ch.title}
-              </CardTitle>
-            </CardHeader>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg font-semibold text-purple-700 dark:text-purple-400">
+              {ch.title}
+            </CardTitle>
+            {ch.description && (
+              <p className="text-sm text-muted-foreground mt-1">{ch.description}</p>
+            )}
+          </CardHeader>
             <CardContent className="flex items-center justify-between">
               <div className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
                 <p className="flex items-center">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -703,6 +703,9 @@ const Home = () => {
                     <CardTitle className="text-lg font-semibold text-purple-700 dark:text-purple-400">
                       {ch.title}
                     </CardTitle>
+                    {ch.description && (
+                      <p className="text-sm text-muted-foreground mt-1">{ch.description}</p>
+                    )}
                   </CardHeader>
                   <CardContent className="flex items-center justify-between">
                     <div className="space-y-1 text-sm text-gray-700 dark:text-gray-300">

--- a/src/pages/admin/DailyChallengeManager.tsx
+++ b/src/pages/admin/DailyChallengeManager.tsx
@@ -27,8 +27,8 @@ const DailyChallengeManager = () => {
   });
 
   const createMutation = useMutation({
-    mutationFn: ({ title, reward, requiredCorrect, timeLimit }: { title: string; reward: number; requiredCorrect: number; timeLimit: number }) =>
-      adminCreateChallenge(title, reward, requiredCorrect, timeLimit),
+    mutationFn: ({ title, reward, requiredCorrect, timeLimit, description }: { title: string; reward: number; requiredCorrect: number; timeLimit: number; description?: string }) =>
+      adminCreateChallenge(title, reward, requiredCorrect, timeLimit, description),
     onSuccess: () => {
       toast.success('Challenge created');
       queryClient.invalidateQueries({ queryKey: ['daily-challenges-admin'] });
@@ -36,12 +36,13 @@ const DailyChallengeManager = () => {
     onError: (err: any) => toast.error(err.response?.data?.error || 'Failed'),
   });
 
-  const [createForm, setCreateForm] = useState({ title: '', reward: '', requiredCorrect: '', timeLimit: '' });
+  const [createForm, setCreateForm] = useState({ title: '', description: '', reward: '', requiredCorrect: '', timeLimit: '' });
   const [questionForm, setQuestionForm] = useState({ text: '', a: '', b: '', c: '', d: '', correct: 'a' });
   const [activeChallenge, setActiveChallenge] = useState<string | null>(null);
   const [bulkChallenge, setBulkChallenge] = useState<string | null>(null);
   const [bulkText, setBulkText] = useState('');
   const [viewChallenge, setViewChallenge] = useState<string | null>(null);
+  const [editQuestion, setEditQuestion] = useState<{ id: string; text: string; options: string[]; correctAnswer: string } | null>(null);
 
   const questionMutation = useMutation({
     mutationFn: ({ cid, text, options, correct }: { cid: string; text: string; options: string[]; correct: string }) =>
@@ -84,6 +85,7 @@ const DailyChallengeManager = () => {
           <CardTitle>{ch.title}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
+          {ch.description && <p className="text-sm text-muted-foreground">{ch.description}</p>}
           <p className="text-sm">Reward: ₹{ch.reward}</p>
           <p className="text-sm">Questions: {count ?? '...'}/{ch.requiredCorrect}</p>
           <div className="flex gap-2 flex-wrap">
@@ -113,6 +115,10 @@ const DailyChallengeManager = () => {
               <SanitizedInput value={createForm.title} onChange={v => setCreateForm(f => ({ ...f, title: v }))} />
             </div>
             <div>
+              <Label>Description</Label>
+              <SanitizedTextarea value={createForm.description} onChange={v => setCreateForm(f => ({ ...f, description: v }))} />
+            </div>
+            <div>
               <Label>Reward</Label>
               <SanitizedInput value={createForm.reward} onChange={v => setCreateForm(f => ({ ...f, reward: v }))} type="number" />
             </div>
@@ -124,7 +130,7 @@ const DailyChallengeManager = () => {
               <Label>Time Limit (seconds)</Label>
               <SanitizedInput value={createForm.timeLimit} onChange={v => setCreateForm(f => ({ ...f, timeLimit: v }))} type="number" />
             </div>
-            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit) })}>Create</Button>
+            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit), description: createForm.description })}>Create</Button>
           </div>
         </DialogContent>
       </Dialog>
@@ -205,13 +211,14 @@ const DailyChallengeManager = () => {
             {questionList?.map(q => (
               <div key={q.id} className="border p-2 rounded text-sm space-y-1">
                 <div>{q.text}</div>
+                <ul className="list-disc ml-4 text-xs space-y-1">
+                  {q.options.map((o, idx) => (
+                    <li key={idx}>{o}</li>
+                  ))}
+                </ul>
+                <p className="text-xs">Correct: {q.correctAnswer}</p>
                 <div className="flex gap-2">
-                  <Button size="sm" onClick={() => {
-                    const text = prompt('Question text', q.text) || q.text;
-                    const opts = q.options.map((o, i) => prompt(`Option ${i+1}`, o) || o);
-                    const correct = prompt('Correct answer', q.correctAnswer) || q.correctAnswer;
-                    adminUpdateQuestion(viewChallenge!, q.id, text, opts, correct).then(() => refetchQuestions());
-                  }}>Edit</Button>
+                  <Button size="sm" onClick={() => setEditQuestion(q)}>Edit</Button>
                   <Button size="sm" variant="destructive" onClick={() => {
                     if (confirm('Delete this question?')) {
                       adminDeleteQuestion(viewChallenge!, q.id).then(() => refetchQuestions());
@@ -222,6 +229,43 @@ const DailyChallengeManager = () => {
             ))}
             {questionList && questionList.length === 0 && <p>No questions</p>}
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!editQuestion} onOpenChange={() => setEditQuestion(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Question</DialogTitle>
+          </DialogHeader>
+          {editQuestion && (
+            <div className="space-y-4">
+              <div>
+                <Label>Question Text</Label>
+                <SanitizedTextarea value={editQuestion.text} onChange={v => setEditQuestion(q => q ? { ...q, text: v } : q)} />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {editQuestion.options.map((opt, idx) => (
+                  <SanitizedInput key={idx} value={opt} onChange={v => setEditQuestion(q => {
+                    if (!q) return q;
+                    const opts = [...q.options];
+                    opts[idx] = v;
+                    return { ...q, options: opts };
+                  })} placeholder={`Option ${String.fromCharCode(65 + idx)}`} />
+                ))}
+              </div>
+              <div>
+                <Label>Correct Option</Label>
+                <SanitizedInput value={editQuestion.correctAnswer} onChange={v => setEditQuestion(q => q ? { ...q, correctAnswer: v } : q)} />
+              </div>
+              <Button onClick={() => {
+                if (!editQuestion || !viewChallenge) return;
+                adminUpdateQuestion(viewChallenge, editQuestion.id, editQuestion.text, editQuestion.options, editQuestion.correctAnswer).then(() => {
+                  setEditQuestion(null);
+                  refetchQuestions();
+                });
+              }}>Update</Button>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -10,6 +10,7 @@ export interface DailyChallenge {
   reward: number;
   requiredCorrect: number;
   timeLimit: number;
+  description?: string;
   active: boolean;
 }
 
@@ -99,6 +100,7 @@ export const adminCreateChallenge = async (
   reward: number,
   requiredCorrect: number,
   timeLimit: number,
+  description?: string,
 ): Promise<string> => {
   const api = await createAdminApi();
   const res = await api.post('/api/daily-challenges', {
@@ -106,6 +108,7 @@ export const adminCreateChallenge = async (
     reward,
     requiredCorrect,
     timeLimit,
+    description,
   });
   return res.data.id;
 };


### PR DESCRIPTION
## Summary
- support description when creating daily challenges
- show description on challenge cards
- add description input in admin create dialog
- allow editing MCQs with a form dialog

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cd69737a4832bb25e23f70cb09c6a