### PR TITLE
Add practice link to daily challenges

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -34,22 +34,46 @@ const checkTimeLimitAndUpdate = async (
 
 export const createChallenge = async (req: Request, res: Response) => {
   try {
-    const { title, reward, requiredCorrect, timeLimit, description } = req.body as {
+    const {
+      title,
+      reward,
+      requiredCorrect,
+      timeLimit,
+      description,
+      practiceUrl,
+    } = req.body as {
       title: string;
       reward: number;
       requiredCorrect: number;
       timeLimit: number;
       description?: string;
+      practiceUrl?: string;
     };
+
     if (!title || !reward || !requiredCorrect || !timeLimit) {
       return res.status(400).json({ error: 'Missing fields' });
     }
+
+    let validatedUrl = '';
+    if (practiceUrl) {
+      try {
+        const url = new URL(practiceUrl);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+          throw new Error('Invalid protocol');
+        }
+        validatedUrl = url.toString();
+      } catch {
+        return res.status(400).json({ error: 'Invalid practice URL' });
+      }
+    }
+
     const challengeRef = await db.collection('daily-challenges').add({
       title,
       reward,
       requiredCorrect,
       timeLimit,
       description: description || '',
+      practiceUrl: validatedUrl,
       active: true,
       createdAt: new Date().toISOString(),
     });

--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -105,12 +105,19 @@ const DailyChallenges = () => {
                   Time Limit: {ch.timeLimit}s
                 </p>
               </div>
-              <Button
-                className="bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white"
-                onClick={() => handleStart(ch)}
-              >
-                {played[ch.id] ? 'View Result' : 'Start'}
-              </Button>
+              <div className="flex flex-col items-end gap-2">
+                {ch.practiceUrl && (
+                  <Button variant="secondary" asChild>
+                    <a href={ch.practiceUrl} target="_blank" rel="noopener noreferrer">Practice</a>
+                  </Button>
+                )}
+                <Button
+                  className="bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white"
+                  onClick={() => handleStart(ch)}
+                >
+                  {played[ch.id] ? 'View Result' : 'Start'}
+                </Button>
+              </div>
             </CardContent>
           </Card>
         ))}

--- a/src/pages/admin/DailyChallengeManager.tsx
+++ b/src/pages/admin/DailyChallengeManager.tsx
@@ -27,8 +27,8 @@ const DailyChallengeManager = () => {
   });
 
   const createMutation = useMutation({
-    mutationFn: ({ title, reward, requiredCorrect, timeLimit, description }: { title: string; reward: number; requiredCorrect: number; timeLimit: number; description?: string }) =>
-      adminCreateChallenge(title, reward, requiredCorrect, timeLimit, description),
+    mutationFn: ({ title, reward, requiredCorrect, timeLimit, description, practiceUrl }: { title: string; reward: number; requiredCorrect: number; timeLimit: number; description?: string; practiceUrl?: string }) =>
+      adminCreateChallenge(title, reward, requiredCorrect, timeLimit, description, practiceUrl),
     onSuccess: () => {
       toast.success('Challenge created');
       queryClient.invalidateQueries({ queryKey: ['daily-challenges-admin'] });
@@ -36,7 +36,7 @@ const DailyChallengeManager = () => {
     onError: (err: any) => toast.error(err.response?.data?.error || 'Failed'),
   });
 
-  const [createForm, setCreateForm] = useState({ title: '', description: '', reward: '', requiredCorrect: '', timeLimit: '' });
+  const [createForm, setCreateForm] = useState({ title: '', description: '', practiceUrl: '', reward: '', requiredCorrect: '', timeLimit: '' });
   const [questionForm, setQuestionForm] = useState({ text: '', a: '', b: '', c: '', d: '', correct: 'a' });
   const [activeChallenge, setActiveChallenge] = useState<string | null>(null);
   const [bulkChallenge, setBulkChallenge] = useState<string | null>(null);
@@ -119,6 +119,10 @@ const DailyChallengeManager = () => {
               <SanitizedTextarea value={createForm.description} onChange={v => setCreateForm(f => ({ ...f, description: v }))} />
             </div>
             <div>
+              <Label>Practice URL</Label>
+              <SanitizedInput value={createForm.practiceUrl} onChange={v => setCreateForm(f => ({ ...f, practiceUrl: v }))} />
+            </div>
+            <div>
               <Label>Reward</Label>
               <SanitizedInput value={createForm.reward} onChange={v => setCreateForm(f => ({ ...f, reward: v }))} type="number" />
             </div>
@@ -130,7 +134,7 @@ const DailyChallengeManager = () => {
               <Label>Time Limit (seconds)</Label>
               <SanitizedInput value={createForm.timeLimit} onChange={v => setCreateForm(f => ({ ...f, timeLimit: v }))} type="number" />
             </div>
-            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit), description: createForm.description })}>Create</Button>
+            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit), description: createForm.description, practiceUrl: createForm.practiceUrl })}>Create</Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -12,6 +12,7 @@ export interface DailyChallenge {
   timeLimit: number;
   description?: string;
   active: boolean;
+  practiceUrl?: string;
 }
 
 export interface ChallengeStatus {
@@ -101,6 +102,7 @@ export const adminCreateChallenge = async (
   requiredCorrect: number,
   timeLimit: number,
   description?: string,
+  practiceUrl?: string,
 ): Promise<string> => {
   const api = await createAdminApi();
   const res = await api.post('/api/daily-challenges', {
@@ -109,6 +111,7 @@ export const adminCreateChallenge = async (
     requiredCorrect,
     timeLimit,
     description,
+    practiceUrl,
   });
   return res.data.id;
 };


### PR DESCRIPTION
## Summary
- allow daily challenge creation to include a practice URL
- support practice URL on the API layer
- update admin form to capture practice URL
- show a Practice button for each challenge

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687d0dc314f4832b8406b1fb143107cd