### PR TITLE
Improve daily challenge speed

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -448,12 +448,28 @@ export const submitAnswer = async (req: Request, res: Response) => {
       });
     }
 
+    let nextQuestion: any = null;
+    if (!completed) {
+      const attemptedQuestions = [...entry.attemptedQuestions, questionId];
+      const available = questionsSnap.docs.filter(
+        q => !attemptedQuestions.includes(q.id),
+      );
+      if (available.length > 0) {
+        const randomDoc =
+          available[Math.floor(Math.random() * available.length)];
+        const data = randomDoc.data() as any;
+        const { correctAnswer, ...question } = data;
+        nextQuestion = { id: randomDoc.id, ...question };
+      }
+    }
+
     res.json({
       correct: isCorrect,
       correctCount,
       completed,
       won,
       timeLimit,
+      nextQuestion,
     });
   } catch (error) {
     console.error('Error submitting answer:', error);

--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -72,7 +72,8 @@ const DailyChallengePlay = () => {
   }, [timeLeft, status, challengeId]);
 
   const submitMutation = useMutation({
-    mutationFn: (index: number) => submitAnswer(challengeId!, question!.id, index),
+    mutationFn: (index: number) =>
+      submitAnswer(challengeId!, question!.id, index),
     onSuccess: data => {
       // merge with existing status so startedAt is preserved for timer
       setStatus(prev => ({
@@ -81,6 +82,9 @@ const DailyChallengePlay = () => {
       }));
       if (data.completed) {
         toast.success(data.won ? 'You won!' : 'Challenge over');
+      } else if (data.nextQuestion) {
+        setQuestion(data.nextQuestion);
+        setSelectedIndex(null);
       } else {
         fetchNext();
       }

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -77,7 +77,9 @@ export const submitAnswer = async (
   challengeId: string,
   questionId: string,
   answerIndex: number,
-): Promise<ChallengeStatus & { correct: boolean }> => {
+): Promise<
+  ChallengeStatus & { correct: boolean; nextQuestion?: ChallengeQuestion }
+> => {
   const token = await getAuthToken();
   const res = await axios.post(
     `${API_URL}/api/daily-challenges/${challengeId}/answer`,


### PR DESCRIPTION
## Summary
- optimize answer submission to immediately return next question
- update API client types for new field
- update daily challenge play page to use returned next question

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc -p backend/tsconfig.json --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687d1d4a5cd4832b91a1664ea49177f8