### PR TITLE
Add max participants limit for MegaTests

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -146,6 +146,12 @@ export const registerForMegaTest = async (req: Request, res: Response) => {
       return res.status(404).json({ error: 'Mega test not found' });
     }
     const megaTest = megaTestDoc.data() as any;
+    if (megaTest.maxParticipants) {
+      const participantsSnap = await megaTestRef.collection('participants').get();
+      if (participantsSnap.size >= megaTest.maxParticipants) {
+        return res.status(400).json({ error: 'Mega test participant limit reached' });
+      }
+    }
     const entryFee = megaTest.entryFee || 0;
 
     const balanceRef = db.collection('balance').doc(userId);

--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -75,6 +75,7 @@ const MegaTestManager = () => {
     entryFee: 0,
     prizes: [] as { rank: number; prize: number }[],
     timeLimit: 60, // Default 60 minutes
+    maxParticipants: 0,
   });
 
   const [questionForm, setQuestionForm] = useState({
@@ -156,6 +157,7 @@ const MegaTestManager = () => {
         entryFee: 0,
         prizes: [],
         timeLimit: 60,
+        maxParticipants: 0,
       });
       toast.success('Mega test created successfully');
     },
@@ -184,6 +186,7 @@ const MegaTestManager = () => {
         entryFee: 0,
         prizes: [],
         timeLimit: 60,
+        maxParticipants: 0,
       });
       toast.success('Mega test updated successfully');
     },
@@ -256,6 +259,7 @@ const MegaTestManager = () => {
         entryFee: megaTest.entryFee,
         prizes: prizes || [],
         timeLimit: megaTest.timeLimit || 60,
+        maxParticipants: megaTest.maxParticipants || 0,
       });
       setIsEditDialogOpen(true);
     } finally {
@@ -678,6 +682,18 @@ const MegaTestManager = () => {
                   step="1"
                   value={formData.timeLimit}
                   onChange={(e) => setFormData({ ...formData, timeLimit: parseInt(e.target.value) || 60 })}
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="maxParticipants">Max Participants (0 for unlimited)</Label>
+                <Input
+                  id="maxParticipants"
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={formData.maxParticipants}
+                  onChange={(e) => setFormData({ ...formData, maxParticipants: parseInt(e.target.value) || 0 })}
                   required
                 />
               </div>
@@ -1158,6 +1174,18 @@ const MegaTestManager = () => {
                 step="1"
                 value={formData.timeLimit}
                 onChange={(e) => setFormData({ ...formData, timeLimit: parseInt(e.target.value) || 60 })}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-maxParticipants">Max Participants (0 for unlimited)</Label>
+              <Input
+                id="edit-maxParticipants"
+                type="number"
+                min="0"
+                step="1"
+                value={formData.maxParticipants}
+                onChange={(e) => setFormData({ ...formData, maxParticipants: parseInt(e.target.value) || 0 })}
                 required
               />
             </div>

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -42,6 +42,7 @@ export interface MegaTest {
   status: 'upcoming' | 'registration' | 'ongoing' | 'completed';
   entryFee: number;
   timeLimit: number;
+  maxParticipants?: number;
 }
 
 export interface MegaTestQuestion {

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -434,6 +434,7 @@ export interface MegaTest {
   status: 'upcoming' | 'registration' | 'ongoing' | 'completed';
   entryFee: number;
   timeLimit: number; // Time limit in minutes
+  maxParticipants?: number;
   questions?: QuizQuestion[];
 }
 
@@ -534,7 +535,7 @@ export const getMegaTestPrizes = async (megaTestId: string): Promise<MegaTestPri
   }
 };
 
-export const createMegaTest = async (data: Omit<MegaTest, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'totalQuestions'> & { 
+export const createMegaTest = async (data: Omit<MegaTest, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'totalQuestions'> & {
   questions: MegaTestQuestion[]; // Original type
   prizes: MegaTestPrize[];
 }): Promise<MegaTest | null> => {
@@ -551,7 +552,8 @@ export const createMegaTest = async (data: Omit<MegaTest, 'id' | 'createdAt' | '
       status: 'upcoming',
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
-      timeLimit: data.timeLimit || 60 
+      timeLimit: data.timeLimit || 60,
+      maxParticipants: data.maxParticipants ?? null
     });
     
     // Create questions in subcollection


### PR DESCRIPTION
## Summary
- allow MegaTests to define a maxParticipants field
- expose maxParticipants in the API and Firebase services
- handle participant limit in backend registration
- add max participants input in admin panel

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f31c660832b94a76f12e4e69797