### PR TITLE
Add realtime MegaTest participant progress bar

### DIFF
--- a/src/components/MegaTestParticipantProgress.tsx
+++ b/src/components/MegaTestParticipantProgress.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Progress } from '@/components/ui/progress';
+import { useMegaTestParticipantCount } from '@/hooks/useMegaTestParticipantCount';
+
+interface Props {
+  megaTestId: string;
+  maxParticipants: number;
+}
+
+const MegaTestParticipantProgress: React.FC<Props> = ({ megaTestId, maxParticipants }) => {
+  const count = useMegaTestParticipantCount(megaTestId);
+
+  if (!maxParticipants || maxParticipants <= 0) return null;
+
+  const percentage = Math.min(100, (count / maxParticipants) * 100);
+  const spotsLeft = Math.max(0, maxParticipants - count);
+
+  return (
+    <div className="space-y-1">
+      <Progress value={percentage} className="h-2" />
+      <div className="text-xs text-muted-foreground">
+        {count} / {maxParticipants} registered{spotsLeft > 0 ? ` – ${spotsLeft} spots left` : ' – Full'}
+      </div>
+    </div>
+  );
+};
+
+export default MegaTestParticipantProgress;

--- a/src/hooks/useMegaTestParticipantCount.ts
+++ b/src/hooks/useMegaTestParticipantCount.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '@/services/firebase';
+
+export const useMegaTestParticipantCount = (megaTestId: string) => {
+  const [count, setCount] = useState<number>(0);
+
+  useEffect(() => {
+    if (!megaTestId) return;
+
+    const ref = collection(db, 'mega-tests', megaTestId, 'participants');
+    const unsubscribe = onSnapshot(ref, (snapshot) => {
+      setCount(snapshot.size);
+    });
+
+    return () => unsubscribe();
+  }, [megaTestId]);
+
+  return count;
+};

--- a/src/pages/AllMegaTests.tsx
+++ b/src/pages/AllMegaTests.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { useAuth } from '../App';
 import MegaTestLeaderboard from '../components/MegaTestLeaderboard';
 import MegaTestPrizes from '../components/MegaTestPrizes';
+import MegaTestParticipantProgress from '../components/MegaTestParticipantProgress';
 import { useState } from 'react';
 import RegistrationCountdown from '../components/RegistrationCountdown';
 
@@ -186,6 +187,12 @@ const AllMegaTests = () => {
                   </div>
                   <div className="mt-2">
                     <MegaTestPrizes megaTestId={megaTest.id} />
+                  </div>
+                  <div className="mt-2">
+                    <MegaTestParticipantProgress
+                      megaTestId={megaTest.id}
+                      maxParticipants={megaTest.maxParticipants || 0}
+                    />
                   </div>
                   <div className="flex justify-end gap-2 mt-4">
                     {!user ? (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,7 @@ import { toast } from 'sonner';
 import MegaTestLeaderboard from "../components/MegaTestLeaderboard";
 import { getCookie } from '@/utils/cookies';
 import MegaTestPrizes from "../components/MegaTestPrizes";
+import MegaTestParticipantProgress from "../components/MegaTestParticipantProgress";
 import { 
   DropdownMenu, 
   DropdownMenuContent, 
@@ -599,6 +600,12 @@ const Home = () => {
                               </div>
                               <div className="mt-2">
                                 <MegaTestPrizes megaTestId={megaTest.id} />
+                              </div>
+                              <div className="mt-2">
+                                <MegaTestParticipantProgress
+                                  megaTestId={megaTest.id}
+                                  maxParticipants={megaTest.maxParticipants || 0}
+                                />
                               </div>
                               <div className="flex justify-end gap-2 mt-4">
                                 {!isAuthenticated ? (


### PR DESCRIPTION
## Summary
- show realtime participant progress using Firestore
- display participant progress on home and listing pages

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build` *(fails: Could not resolve "./withdrawal" from firebase index)*

------
https://chatgpt.com/codex/tasks/task_e_687e5728d344832bab680b4d139b1da4