### PR TITLE
Fix daily challenge status 404

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -268,15 +268,22 @@ export const getChallengeStatus = async (req: Request, res: Response) => {
       .collection('daily-challenge-entries')
       .doc(entryId)
       .get();
-    if (!entryDoc.exists) {
-      return res.status(404).json({ error: 'Challenge not started' });
-    }
+
     const challengeDoc = await db.collection('daily-challenges').doc(challengeId).get();
     const challenge = challengeDoc.data() as any;
     const timeLimit = challengeDoc.exists ? challenge.timeLimit : 0;
+
+    if (!entryDoc.exists) {
+      return res.json({ started: false, timeLimit });
+    }
+
     const entryRef = db.collection('daily-challenge-entries').doc(entryId);
-    const updatedEntry = await checkTimeLimitAndUpdate(entryRef, entryDoc.data() as ChallengeEntry, challenge);
-    res.json({ ...updatedEntry, timeLimit });
+    const updatedEntry = await checkTimeLimitAndUpdate(
+      entryRef,
+      entryDoc.data() as ChallengeEntry,
+      challenge,
+    );
+    res.json({ started: true, ...updatedEntry, timeLimit });
   } catch (error) {
     console.error('Error getting status:', error);
     res.status(500).json({ error: 'Failed to get status' });

--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -41,6 +41,10 @@ const DailyChallengePlay = () => {
     const loadStatusAndQuestion = async () => {
       try {
         const statusData = await getChallengeStatus(challengeId);
+        if (!statusData.started) {
+          toast.error('Challenge not started');
+          return;
+        }
         setStatus(statusData);
         if (!statusData.completed) {
           await fetchNext();
@@ -66,7 +70,9 @@ const DailyChallengePlay = () => {
   useEffect(() => {
     if (timeLeft === 0 && status && !status.completed && challengeId) {
       getChallengeStatus(challengeId)
-        .then(d => setStatus(d))
+        .then(d => {
+          if (d.started) setStatus(d);
+        })
         .catch(() => {});
     }
   }, [timeLeft, status, challengeId]);

--- a/src/pages/DailyChallenges.tsx
+++ b/src/pages/DailyChallenges.tsx
@@ -39,9 +39,7 @@ const DailyChallenges = () => {
       if (!user || !challenges) return;
       const results = await Promise.all(
         challenges.map(ch =>
-          getChallengeStatus(ch.id)
-            .then(() => true)
-            .catch(() => false),
+          getChallengeStatus(ch.id).then(status => status.started),
         ),
       );
       const map: Record<string, boolean> = {};
@@ -59,8 +57,8 @@ const DailyChallenges = () => {
       return;
     }
     try {
-      const status = await getChallengeStatus(challenge.id).catch(() => null);
-      if (!status) {
+      const status = await getChallengeStatus(challenge.id);
+      if (!status.started) {
         await startMutation.mutateAsync(challenge.id);
         setPlayed(prev => ({ ...prev, [challenge.id]: true }));
       } else {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -143,9 +143,7 @@ const Home = () => {
       if (!user || !dailyChallenges) return;
       const results = await Promise.all(
         dailyChallenges.map(ch =>
-          getChallengeStatus(ch.id)
-            .then(() => true)
-            .catch(() => false),
+          getChallengeStatus(ch.id).then(status => status.started),
         ),
       );
       const map: Record<string, boolean> = {};
@@ -159,8 +157,8 @@ const Home = () => {
 
   const handleStartChallenge = async (ch: DailyChallenge) => {
     if (!user) { toast.error('Please login first'); navigate('/auth'); return; }
-    const status = await getChallengeStatus(ch.id).catch(() => null);
-    if (!status) {
+    const status = await getChallengeStatus(ch.id);
+    if (!status.started) {
       await startMutation.mutateAsync(ch.id);
       setPlayedChallenges(prev => ({ ...prev, [ch.id]: true }));
     } else {

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -16,14 +16,15 @@ export interface DailyChallenge {
 }
 
 export interface ChallengeStatus {
-  userId: string;
-  challengeId: string;
-  date: string;
-  correctCount: number;
-  attemptedQuestions: string[];
-  completed: boolean;
-  won: boolean;
-  startedAt: string;
+  started: boolean;
+  userId?: string;
+  challengeId?: string;
+  date?: string;
+  correctCount?: number;
+  attemptedQuestions?: string[];
+  completed?: boolean;
+  won?: boolean;
+  startedAt?: string;
   completedAt?: string;
   timeLimit: number;
 }


### PR DESCRIPTION
## Summary
- adjust daily challenge status API to return `started: false` instead of 404
- extend `ChallengeStatus` interface with optional fields
- update React pages to use new API shape

## Testing
- `npm run lint` *(fails: Unexpected any and other eslint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fa7c12bec832b81a164d68cc1f096