### PR TITLE
Secure MegaTest submission

### DIFF
--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -166,7 +166,7 @@ export interface SubmitMegaTestResultResponse {
 export const submitMegaTestResult = async (
   megaTestId: string,
   answers: MegaTestAnswers,
-  completionTime: number
+  completionTime?: number
 ): Promise<SubmitMegaTestResultResponse> => {
   const token = await getAuthToken();
   const res = await axios.post(


### PR DESCRIPTION
## Summary
- protect mega test questions from leaking answers
- ignore client-provided completion time during submission
- require start time to exist for valid submissions

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fbb00d50c832bbb4d40ccb7767384