### PR TITLE
Remove debug logs from MegaTest page

### DIFF
--- a/src/pages/MegaTest.tsx
+++ b/src/pages/MegaTest.tsx
@@ -96,10 +96,8 @@ const MegaTest = () => {
     checkSubmissionStatus();
   }, [megaTestId, user, navigate]);
 
-  if (import.meta.env.DEV) {
-    console.log('MegaTest data:', data);
-    console.log('MegaTest questions:', data?.questions);
-  }
+  // Remove verbose console logging of quiz data
+  // to avoid exposing MegaTest details in the browser console.
 
   const { megaTest, questions } = data || { megaTest: null, questions: [] };
 


### PR DESCRIPTION
## Summary
- remove console logging of mega test data so details aren't leaked in browser console

## Testing
- `npm run lint` *(fails: 135 errors, 22 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fbf85309c832bb932024d38b0c482