### PR TITLE
Add MegaTest visibility toggle

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -94,7 +94,7 @@ export const getMegaTestLeaderboard = async (req: Request, res: Response) => {
 
 export const getMegaTests = async (_req: Request, res: Response) => {
   try {
-    const snap = await db.collection('mega-tests').get();
+    const snap = await db.collection('mega-tests').where('enabled', '==', true).get();
     const tests = snap.docs
       .map(doc => ({ id: doc.id, ...doc.data() }))
       .sort((a, b) => {

--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -26,6 +26,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
 import { Plus, Pencil, Trash2, Clock, Trophy, ListChecks, CreditCard, Users, Upload } from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
@@ -78,6 +79,7 @@ const MegaTestManager = () => {
     prizes: [] as { rank: number; prize: number }[],
     timeLimit: 60, // Default 60 minutes
     maxParticipants: 0,
+    enabled: false,
   });
 
   const [questionForm, setQuestionForm] = useState({
@@ -161,6 +163,7 @@ const MegaTestManager = () => {
         prizes: [],
         timeLimit: 60,
         maxParticipants: 0,
+        enabled: false,
       });
       toast.success('Mega test created successfully');
     },
@@ -191,6 +194,7 @@ const MegaTestManager = () => {
         prizes: [],
         timeLimit: 60,
         maxParticipants: 0,
+        enabled: false,
       });
       toast.success('Mega test updated successfully');
     },
@@ -267,6 +271,7 @@ const MegaTestManager = () => {
         prizes: prizes || [],
         timeLimit: megaTest.timeLimit || 60,
         maxParticipants: megaTest.maxParticipants || 0,
+        enabled: megaTest.enabled ?? false,
       });
       setIsEditDialogOpen(true);
     } finally {
@@ -762,7 +767,13 @@ const MegaTestManager = () => {
           <Card key={megaTest.id}>
             <CardHeader>
               <div className="flex justify-between items-center">
-                <CardTitle>{megaTest.title}</CardTitle>
+                <div className="flex items-center gap-2">
+                  <CardTitle>{megaTest.title}</CardTitle>
+                  <Switch
+                    checked={!!megaTest.enabled}
+                    onCheckedChange={(checked) => updateMutation.mutate({ id: megaTest.id, data: { enabled: checked } })}
+                  />
+                </div>
                 <div className="flex gap-2">
                   <Button
                     variant="outline"

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -44,6 +44,7 @@ export interface MegaTest {
   entryFee: number;
   timeLimit: number;
   maxParticipants?: number;
+  enabled?: boolean;
 }
 
 export interface MegaTestQuestion {

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -436,6 +436,7 @@ export interface MegaTest {
   entryFee: number;
   timeLimit: number; // Time limit in minutes
   maxParticipants?: number;
+  enabled?: boolean;
   questions?: QuizQuestion[];
 }
 
@@ -555,7 +556,8 @@ export const createMegaTest = async (data: Omit<MegaTest, 'id' | 'createdAt' | '
       updatedAt: serverTimestamp(),
       timeLimit: data.timeLimit || 60,
       maxParticipants: data.maxParticipants ?? null,
-      practiceUrl: data.practiceUrl || ''
+      practiceUrl: data.practiceUrl || '',
+      enabled: false
     });
     
     // Create questions in subcollection


### PR DESCRIPTION
## Summary
- allow backend to return only visible mega tests
- add `enabled` property to MegaTest interfaces
- default newly created mega tests to disabled
- reset forms to disabled state in admin manager
- allow admin to toggle mega test visibility from MegaTestManager

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68808748f214832b980d1c7f9d427865