### PR TITLE
Fix practice URL handling

### DIFF
--- a/src/pages/AllMegaTests.tsx
+++ b/src/pages/AllMegaTests.tsx
@@ -203,6 +203,14 @@ const AllMegaTests = () => {
                     </div>
                   )}
                   <div className="flex justify-end gap-2 mt-4">
+                    {megaTest.practiceUrl && (
+                      <Button
+                        asChild
+                        className="bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white"
+                      >
+                        <a href={megaTest.practiceUrl} target="_blank" rel="noopener noreferrer">Practice</a>
+                      </Button>
+                    )}
                     {!user ? (
                       <Button
                         className="w-full bg-pink-600 hover:bg-pink-700 text-white font-bold py-2 rounded-lg shadow-md transition-colors duration-300"
@@ -212,14 +220,6 @@ const AllMegaTests = () => {
                       </Button>
                     ) : (
                       <>
-                        {megaTest.practiceUrl && (
-                          <Button
-                            asChild
-                            className="bg-gradient-to-r from-purple-500 to-indigo-500 hover:from-purple-600 hover:to-indigo-600 text-white"
-                          >
-                            <a href={megaTest.practiceUrl} target="_blank" rel="noopener noreferrer">Practice</a>
-                          </Button>
-                        )}
                         {status === 'registration' && !isRegistered && (
                           <Button
                             className="w-full bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 hover:from-pink-600 hover:to-green-500 text-white font-bold py-2 rounded-lg shadow-md transition-all duration-300"

--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -265,26 +265,32 @@ const MegaTestManager = () => {
   const handleEdit = async (megaTest: MegaTest) => {
     setIsLoadingEditQuestions(true);
     try {
-      const [{ questions }, prizes] = await Promise.all([
+      const [{ megaTest: fullMegaTest, questions }, prizes] = await Promise.all([
         getMegaTestById(megaTest.id),
         getMegaTestPrizes(megaTest.id)
       ]);
-      setSelectedMegaTest(megaTest);
+
+      if (!fullMegaTest) {
+        toast.error('Failed to fetch mega test details');
+        return;
+      }
+
+      setSelectedMegaTest(fullMegaTest);
       setFormData({
-        title: megaTest.title,
-        description: megaTest.description,
-        practiceUrl: megaTest.practiceUrl || '',
+        title: fullMegaTest.title,
+        description: fullMegaTest.description,
+        practiceUrl: fullMegaTest.practiceUrl || '',
         questions: questions || [],
-        registrationStartTime: format(megaTest.registrationStartTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
-        registrationEndTime: format(megaTest.registrationEndTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
-        testStartTime: format(megaTest.testStartTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
-        testEndTime: format(megaTest.testEndTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
-        resultTime: format(megaTest.resultTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
-        entryFee: megaTest.entryFee,
+        registrationStartTime: format(fullMegaTest.registrationStartTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
+        registrationEndTime: format(fullMegaTest.registrationEndTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
+        testStartTime: format(fullMegaTest.testStartTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
+        testEndTime: format(fullMegaTest.testEndTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
+        resultTime: format(fullMegaTest.resultTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
+        entryFee: fullMegaTest.entryFee,
         prizes: prizes || [],
-        timeLimit: megaTest.timeLimit || 60,
-        maxParticipants: megaTest.maxParticipants || 0,
-        enabled: megaTest.enabled ?? false,
+        timeLimit: fullMegaTest.timeLimit || 60,
+        maxParticipants: fullMegaTest.maxParticipants || 0,
+        enabled: fullMegaTest.enabled ?? false,
       });
       setIsEditDialogOpen(true);
     } finally {


### PR DESCRIPTION
## Summary
- show the MegaTest practice link for all visitors
- load practice URL correctly when editing a MegaTest

## Testing
- `npm run lint` *(fails: 137 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed5fd7d0832bb6b4e71e0676bfdf