### PR TITLE
Fix practice URL clearing when toggling MegaTest

### DIFF
--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -732,8 +732,11 @@ export const updateMegaTest = async (
   const updateData: any = {
     ...data,
     updatedAt: serverTimestamp(),
-    practiceUrl: data.practiceUrl ?? ''
   };
+
+  if (data.practiceUrl !== undefined) {
+    updateData.practiceUrl = data.practiceUrl;
+  }
 
     if (data.questions) {
       updateData.totalQuestions = data.questions.length;


### PR DESCRIPTION
## Summary
- don't overwrite `practiceUrl` when updating a MegaTest unless a new value is provided

## Testing
- `npm run lint` *(fails: no-useless-catch, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880f343148c832bb18856fbbd80e589