### PR TITLE
Use backend API for user auth

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -14,6 +14,7 @@ const envSchema = z.object({
   FIREBASE_PROJECT_ID: z.string(),
   FIREBASE_PRIVATE_KEY: z.string(),
   FIREBASE_CLIENT_EMAIL: z.string().email(),
+  FIREBASE_API_KEY: z.string(),
 
   // Admin Configuration
   ADMIN_EMAIL: z.string().email(),


### PR DESCRIPTION
## Summary
- switch frontend auth API to call backend endpoints and sign in with custom tokens
- verify credentials server-side via Firebase REST API
- add `FIREBASE_API_KEY` to backend environment schema

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880f6d8c5d4832b967db1a00e61a2bf