### PR TITLE
Fix leaderboard sorting

### DIFF
--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -555,9 +555,18 @@ const MegaTestManager = () => {
     const filtered = leaderboardEntries.filter(entry => entry.userId !== userId);
     // Recalculate ranks and update Firestore
     const batch = writeBatch(db);
+    const getTime = (val: any) => {
+      if (!val) return 0;
+      if (typeof val === 'string') return new Date(val).getTime();
+      if (typeof val.toMillis === 'function') return val.toMillis();
+      if (val.seconds) return val.seconds * 1000;
+      return new Date(val).getTime();
+    };
+
     filtered.sort((a, b) => {
       if (a.score !== b.score) return b.score - a.score;
-      return a.completionTime - b.completionTime;
+      if (a.completionTime !== b.completionTime) return a.completionTime - b.completionTime;
+      return getTime(a.submittedAt) - getTime(b.submittedAt);
     });
     filtered.forEach((entry, idx) => {
       const entryRef = doc(collection(db, 'mega-tests', leaderboardMegaTest.id, 'leaderboard'), entry.userId);

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -684,11 +684,22 @@ export const submitMegaTestResult = async (
     };
     leaderboard.push(newEntry);
     
+    const getTime = (val: any) => {
+      if (!val) return 0;
+      if (typeof val === 'string') return new Date(val).getTime();
+      if (typeof val.toMillis === 'function') return val.toMillis();
+      if (val.seconds) return val.seconds * 1000;
+      return new Date(val).getTime();
+    };
+
     leaderboard.sort((a, b) => {
       if (a.score !== b.score) {
         return b.score - a.score;
       }
-      return a.completionTime - b.completionTime;
+      if (a.completionTime !== b.completionTime) {
+        return a.completionTime - b.completionTime;
+      }
+      return getTime(a.submittedAt) - getTime(b.submittedAt);
     });
     
     const batch = writeBatch(db);
@@ -929,11 +940,22 @@ export const adminAddOrUpdateLeaderboardEntry = async (
     leaderboard.push(newEntry);
 
     // Sort and assign ranks
+    const getTime = (val: any) => {
+      if (!val) return 0;
+      if (typeof val === 'string') return new Date(val).getTime();
+      if (typeof val.toMillis === 'function') return val.toMillis();
+      if (val.seconds) return val.seconds * 1000;
+      return new Date(val).getTime();
+    };
+
     leaderboard.sort((a, b) => {
       if (a.score !== b.score) {
         return b.score - a.score;
       }
-      return a.completionTime - b.completionTime;
+      if (a.completionTime !== b.completionTime) {
+        return a.completionTime - b.completionTime;
+      }
+      return getTime(a.submittedAt) - getTime(b.submittedAt);
     });
 
     const batch = writeBatch(db);


### PR DESCRIPTION
## Summary
- refine leaderboard ordering logic to handle completion time and submission time
- apply same sorting rules to admin leaderboard management

## Testing
- `npm run lint` *(fails: 166 problems)*
- `npm run lint` in backend *(fails due to invalid option)*

------
https://chatgpt.com/codex/tasks/task_e_688105857c44832b99c6de16228571a9