### PR TITLE
Add exit prompt to daily challenge

### DIFF
--- a/backend/src/routes/dailyChallengeRoutes.ts
+++ b/backend/src/routes/dailyChallengeRoutes.ts
@@ -15,6 +15,7 @@ import {
   getChallengeStatus,
   getNextQuestion,
   submitAnswer,
+  forfeitChallenge,
 } from '../controllers/challengeController.js';
 
 const router = express.Router();
@@ -28,6 +29,7 @@ router.post('/:challengeId/start', startChallenge);
 router.get('/:challengeId/status', getChallengeStatus);
 router.get('/:challengeId/question', getNextQuestion);
 router.post('/:challengeId/answer', submitAnswer);
+router.post('/:challengeId/forfeit', forfeitChallenge);
 
 // Admin actions
 router.use(verifyFirebaseAdmin);

--- a/src/hooks/useExitPrompt.ts
+++ b/src/hooks/useExitPrompt.ts
@@ -1,0 +1,34 @@
+import { useEffect, useCallback } from 'react';
+import { useBlocker, useBeforeUnload } from 'react-router-dom';
+
+export const useExitPrompt = (
+  when: boolean,
+  onExit: () => Promise<void> | void,
+) => {
+  const blocker = useBlocker(when);
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      const proceed = window.confirm('Do you really want to exit?');
+      if (proceed) {
+        Promise.resolve(onExit()).finally(() => {
+          setTimeout(blocker.proceed, 0);
+        });
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker, onExit]);
+
+  useBeforeUnload(
+    useCallback(
+      (e: BeforeUnloadEvent) => {
+        if (when) {
+          e.preventDefault();
+          e.returnValue = '';
+        }
+      },
+      [when],
+    ),
+  );
+};

--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -5,6 +5,7 @@ import {
   getChallengeStatus,
   getNextQuestion,
   submitAnswer,
+  forfeitChallenge,
   getDailyChallenges,
   ChallengeQuestion,
   DailyChallenge,
@@ -19,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
+import { useExitPrompt } from '@/hooks/useExitPrompt';
 
 const DailyChallengePlay = () => {
   const { challengeId } = useParams<{ challengeId: string }>();
@@ -119,6 +121,25 @@ const DailyChallengePlay = () => {
       toast.error(err.response?.data?.error || 'Failed');
     },
   });
+
+  const forfeitMutation = useMutation({
+    mutationFn: () => forfeitChallenge(challengeId!),
+    onSuccess: data => {
+      setStatus(prev => ({ ...(prev || {}), ...data }));
+      toast.success(data.won ? 'Challenge over' : 'Challenge over');
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.error || 'Failed to exit');
+    },
+  });
+
+  const handleExit = async () => {
+    if (!status?.completed) {
+      await forfeitMutation.mutateAsync();
+    }
+  };
+
+  useExitPrompt(!!status && !status.completed, handleExit);
 
   if (!challengeId) return <p>Invalid challenge</p>;
 

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -90,6 +90,18 @@ export const submitAnswer = async (
   return res.data;
 };
 
+export const forfeitChallenge = async (
+  challengeId: string,
+): Promise<ChallengeStatus> => {
+  const token = await getAuthToken();
+  const res = await axios.post(
+    `${API_URL}/api/daily-challenges/${challengeId}/forfeit`,
+    {},
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return res.data;
+};
+
 // --- Admin APIs ---
 const createAdminApi = async () => {
   const token = await refreshAdminToken();


### PR DESCRIPTION
## Summary
- prevent losing challenge progress accidentally
- add forfeit endpoint in backend
- hook up forfeit API on the frontend
- prompt user before leaving a challenge

## Testing
- `npm run build`
- `npm run lint` *(fails: 167 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6881fcc7a1ec832b81c69368ed28942f