### PR TITLE
Add keyword field to MegaTest admin

### DIFF
--- a/src/pages/admin/MegaTestManager.tsx
+++ b/src/pages/admin/MegaTestManager.tsx
@@ -71,6 +71,7 @@ const MegaTestManager = () => {
     title: '',
     description: '',
     practiceUrl: '',
+    keyword: '',
     questions: [] as QuizQuestion[],
     registrationStartTime: '',
     registrationEndTime: '',
@@ -155,6 +156,7 @@ const MegaTestManager = () => {
         title: '',
         description: '',
         practiceUrl: '',
+        keyword: '',
         questions: [],
         registrationStartTime: '',
         registrationEndTime: '',
@@ -186,6 +188,7 @@ const MegaTestManager = () => {
         title: '',
         description: '',
         practiceUrl: '',
+        keyword: '',
         questions: [],
         registrationStartTime: '',
         registrationEndTime: '',
@@ -281,6 +284,7 @@ const MegaTestManager = () => {
         title: fullMegaTest.title,
         description: fullMegaTest.description,
         practiceUrl: fullMegaTest.practiceUrl || '',
+        keyword: fullMegaTest.keyword || '',
         questions: questions || [],
         registrationStartTime: format(fullMegaTest.registrationStartTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
         registrationEndTime: format(fullMegaTest.registrationEndTime.toDate(), "yyyy-MM-dd'T'HH:mm"),
@@ -645,13 +649,21 @@ const MegaTestManager = () => {
                   required
                 />
               </div>
-              <div>
+            <div>
               <Label htmlFor="description">Description</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 required
+              />
+            </div>
+            <div>
+              <Label htmlFor="keyword">Keyword</Label>
+              <Input
+                id="keyword"
+                value={formData.keyword}
+                onChange={(e) => setFormData({ ...formData, keyword: e.target.value })}
               />
             </div>
             <div>
@@ -1166,6 +1178,14 @@ const MegaTestManager = () => {
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 required
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-keyword">Keyword</Label>
+              <Input
+                id="edit-keyword"
+                value={formData.keyword}
+                onChange={(e) => setFormData({ ...formData, keyword: e.target.value })}
               />
             </div>
             <div>

--- a/src/services/api/megaTest.ts
+++ b/src/services/api/megaTest.ts
@@ -31,6 +31,7 @@ export interface MegaTest {
   id: string;
   title: string;
   description: string;
+  keyword?: string;
   practiceUrl?: string;
   registrationStartTime: any;
   registrationEndTime: any;

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -424,6 +424,7 @@ export interface MegaTest {
   id: string;
   title: string;
   description: string;
+  keyword?: string;
   practiceUrl?: string;
   registrationStartTime: Timestamp;
   registrationEndTime: Timestamp;
@@ -550,6 +551,7 @@ export const createMegaTest = async (data: Omit<MegaTest, 'id' | 'createdAt' | '
     // Create main mega test document
     const { prizes, ...megaTestData } = data; // Original destructuring
     batch.set(newMegaTestRef, {
+      keyword: data.keyword || '',
       ...megaTestData, // This will include data.questions as it's part of megaTestData
       totalQuestions: data.questions.length,
       status: 'upcoming',
@@ -867,6 +869,7 @@ export const copyMegaTest = async (megaTestId: string): Promise<MegaTest | null>
     batch.set(newRef, {
       title: originalData.title,
       description: originalData.description,
+      keyword: originalData.keyword || '',
       practiceUrl: originalData.practiceUrl || '',
       registrationStartTime: originalData.registrationStartTime,
       registrationEndTime: originalData.registrationEndTime,


### PR DESCRIPTION
## Summary
- support optional `keyword` field for mega tests
- allow admins to input keywords when creating or editing a mega test
- copy keyword when duplicating a mega test

## Testing
- `npm run build:dev`
- `npm run lint` *(fails: no-useless-catch and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882057629d8832ba9de705d29b5c00e