### PR TITLE
Add keyword field to daily challenge admin form

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -41,6 +41,7 @@ export const createChallenge = async (req: Request, res: Response) => {
       timeLimit,
       description,
       practiceUrl,
+      keyword,
     } = req.body as {
       title: string;
       reward: number;
@@ -48,6 +49,7 @@ export const createChallenge = async (req: Request, res: Response) => {
       timeLimit: number;
       description?: string;
       practiceUrl?: string;
+      keyword?: string;
     };
 
     if (!title || !reward || !requiredCorrect || !timeLimit) {
@@ -74,6 +76,7 @@ export const createChallenge = async (req: Request, res: Response) => {
       timeLimit,
       description: description || '',
       practiceUrl: validatedUrl,
+      keyword: keyword || '',
       active: true,
       createdAt: new Date().toISOString(),
     });
@@ -215,7 +218,11 @@ export const getDailyChallenges = async (_req: Request, res: Response) => {
       .collection('daily-challenges')
       .where('active', '==', true)
       .get();
-    const challenges = snap.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const challenges = snap.docs.map(doc => {
+      const data = doc.data() as any;
+      const { keyword, ...rest } = data;
+      return { id: doc.id, ...rest };
+    });
     res.json(challenges);
   } catch (error) {
     console.error('Error fetching challenges:', error);

--- a/src/pages/admin/DailyChallengeManager.tsx
+++ b/src/pages/admin/DailyChallengeManager.tsx
@@ -27,8 +27,8 @@ const DailyChallengeManager = () => {
   });
 
   const createMutation = useMutation({
-    mutationFn: ({ title, reward, requiredCorrect, timeLimit, description, practiceUrl }: { title: string; reward: number; requiredCorrect: number; timeLimit: number; description?: string; practiceUrl?: string }) =>
-      adminCreateChallenge(title, reward, requiredCorrect, timeLimit, description, practiceUrl),
+    mutationFn: ({ title, reward, requiredCorrect, timeLimit, description, practiceUrl, keyword }: { title: string; reward: number; requiredCorrect: number; timeLimit: number; description?: string; practiceUrl?: string; keyword?: string }) =>
+      adminCreateChallenge(title, reward, requiredCorrect, timeLimit, description, practiceUrl, keyword),
     onSuccess: () => {
       toast.success('Challenge created');
       queryClient.invalidateQueries({ queryKey: ['daily-challenges-admin'] });
@@ -36,7 +36,7 @@ const DailyChallengeManager = () => {
     onError: (err: any) => toast.error(err.response?.data?.error || 'Failed'),
   });
 
-  const [createForm, setCreateForm] = useState({ title: '', description: '', practiceUrl: '', reward: '', requiredCorrect: '', timeLimit: '' });
+  const [createForm, setCreateForm] = useState({ title: '', description: '', practiceUrl: '', keyword: '', reward: '', requiredCorrect: '', timeLimit: '' });
   const [questionForm, setQuestionForm] = useState({ text: '', a: '', b: '', c: '', d: '', correct: 'a' });
   const [activeChallenge, setActiveChallenge] = useState<string | null>(null);
   const [bulkChallenge, setBulkChallenge] = useState<string | null>(null);
@@ -119,6 +119,10 @@ const DailyChallengeManager = () => {
               <SanitizedTextarea value={createForm.description} onChange={v => setCreateForm(f => ({ ...f, description: v }))} />
             </div>
             <div>
+              <Label>Keyword</Label>
+              <SanitizedInput value={createForm.keyword} onChange={v => setCreateForm(f => ({ ...f, keyword: v }))} />
+            </div>
+            <div>
               <Label>Practice URL</Label>
               <SanitizedInput value={createForm.practiceUrl} onChange={v => setCreateForm(f => ({ ...f, practiceUrl: v }))} />
             </div>
@@ -134,7 +138,7 @@ const DailyChallengeManager = () => {
               <Label>Time Limit (seconds)</Label>
               <SanitizedInput value={createForm.timeLimit} onChange={v => setCreateForm(f => ({ ...f, timeLimit: v }))} type="number" />
             </div>
-            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit), description: createForm.description, practiceUrl: createForm.practiceUrl })}>Create</Button>
+            <Button onClick={() => createMutation.mutate({ title: createForm.title, reward: Number(createForm.reward), requiredCorrect: Number(createForm.requiredCorrect), timeLimit: Number(createForm.timeLimit), description: createForm.description, practiceUrl: createForm.practiceUrl, keyword: createForm.keyword })}>Create</Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -13,6 +13,7 @@ export interface DailyChallenge {
   description?: string;
   active: boolean;
   practiceUrl?: string;
+  keyword?: string;
 }
 
 export interface ChallengeStatus {
@@ -106,6 +107,7 @@ export const adminCreateChallenge = async (
   timeLimit: number,
   description?: string,
   practiceUrl?: string,
+  keyword?: string,
 ): Promise<string> => {
   const api = await createAdminApi();
   const res = await api.post('/api/daily-challenges', {
@@ -115,6 +117,7 @@ export const adminCreateChallenge = async (
     timeLimit,
     description,
     practiceUrl,
+    keyword,
   });
   return res.data.id;
 };


### PR DESCRIPTION
## Summary
- support a `keyword` when creating daily challenges in the backend
- hide the keyword from the public daily challenge list
- allow admins to enter keyword via admin UI
- send keyword through admin APIs

## Testing
- `npm run lint` *(fails: 166 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6882090e418c832b805eef3577e34d36