### PR TITLE
Capture IP only during auth

### DIFF
--- a/docs/IP_CAPTURE_SYSTEM.md
+++ b/docs/IP_CAPTURE_SYSTEM.md
@@ -1,7 +1,7 @@
 # IP Address Capturing System
 
 ## Overview
-This system captures and stores the IP addresses of users when they visit the Index.tsx page (logged-in page). The system is designed to work only for regular users and excludes admin users.
+This system captures and stores the IP addresses of users when they register or log in. The system is designed to work only for regular users and excludes admin users.
 
 ## Features
 
@@ -47,20 +47,14 @@ This system captures and stores the IP addresses of users when they visit the In
 - **Purpose**: Calls backend endpoint to capture IP
 - **Error Handling**: Includes token refresh logic
 - **Response Type**: `IPCaptureResponse`
-- **Client Fallback**: Uses multiple public services with a 3s timeout and validates the IP if the backend fails
+- **Client Fallback**: Removed to avoid repeated external requests
 
-#### 2. Index Page Integration (`src/pages/Index.tsx`)
-- **IP Display**: Shows captured IP at the top of the page
-- **User Filtering**: Only shows for authenticated non-admin users
-- **Real-time Updates**: Displays loading state and captured IP
-- **Visual Design**: Blue-themed banner with globe icon
+#### 2. Auth Integration
+- IP address is captured during user registration and login only.
+- The value is stored in Firestore and reused in features like mega tests.
 
 #### 3. State Management
-- **State Variables**:
-  - `userIP`: Stores captured IP address
-  - `isCapturingIP`: Loading state for IP capture
-- **Mutations**: Uses React Query for API calls
-- **Effects**: Automatically captures IP on page load
+No periodic IP capture is performed on the Index page anymore.
 
 ## Security Considerations
 
@@ -80,10 +74,8 @@ This system captures and stores the IP addresses of users when they visit the In
 ## Usage
 
 ### For Users
-1. Log in to the application
-2. Navigate to the Index page
-3. IP address is automatically captured and displayed
-4. IP is stored in Firestore for future reference
+1. Register or log in to the application
+2. Your IP address is captured once and stored in Firestore
 
 ### For Developers
 1. Backend automatically handles IP detection
@@ -100,10 +92,8 @@ This system captures and stores the IP addresses of users when they visit the In
 
 ### Manual Testing
 1. Start backend server
-2. Log in as a regular user
-3. Visit Index page
-4. Verify IP address is displayed
-5. Check Firestore for stored data
+2. Register or log in as a regular user
+3. Verify IP address is stored in Firestore
 
 ## Configuration
 

--- a/src/services/api/user.ts
+++ b/src/services/api/user.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { getAuthToken } from './auth';
 import { getAuth } from 'firebase/auth';
-import { getClientIP } from '../../utils/ipDetection';
 
 const API_URL = import.meta.env.VITE_API_URL || 'https://rajtst-1074455492364.asia-south1.run.app';
 
@@ -123,23 +122,7 @@ export const captureUserIP = async (): Promise<IPCaptureResponse> => {
       throw new Error('Authentication required');
     }
     
-    // If backend fails, try client-side IP detection as fallback
-    if (error.response?.status >= 500 || !error.response) {
-      console.log('Backend IP capture failed, trying client-side detection...');
-      try {
-        const clientIP = await getClientIP();
-        if (clientIP) {
-          return {
-            success: true,
-            ipAddress: clientIP,
-            originalIP: 'client-detected',
-            timestamp: new Date().toISOString()
-          };
-        }
-      } catch (clientError) {
-        console.error('Client-side IP detection also failed:', clientError);
-      }
-    }
+    // If backend fails, propagate the error without attempting additional client-side detection
     
     throw error;
   }

--- a/src/services/firebase/quiz.ts
+++ b/src/services/firebase/quiz.ts
@@ -3,7 +3,6 @@ import { parseTimestamp } from '@/utils/parseTimestamp';
 import { db } from './config';
 import { getMegaTestLeaderboard as fetchLeaderboard, MegaTestLeaderboardEntry } from '../api/megaTest';
 import { updateUserBalance } from './balance';
-import { getClientIP } from '@/utils/ipDetection';
 import { getDeviceId } from '@/utils/deviceId';
 
 export interface QuizCategory {
@@ -622,7 +621,9 @@ export const registerForMegaTest = async (megaTestId: string, userId: string, us
       });
     }
     
-    const ipAddress = await getClientIP();
+    const userRef = doc(db, 'users', userId);
+    const userDoc = await getDoc(userRef);
+    const ipAddress = userDoc.exists() ? (userDoc.data().lastSeenIP || userDoc.data().ipAddress) : undefined;
     const deviceId = getDeviceId();
     
     const participantRef = doc(collection(db, 'mega-tests', megaTestId, 'participants'), userId);


### PR DESCRIPTION
## Summary
- remove periodic IP capture logic
- store user's last seen IP and use it for MegaTest registration
- simplify IP detection to a single request
- update docs to clarify IP capture happens only on login/registration

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688212e05cd0832ba30c2bf5031bd79e