### PR TITLE
Implement 10% withdrawal fee

### DIFF
--- a/backend/src/controllers/withdrawalController.ts
+++ b/backend/src/controllers/withdrawalController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { db } from '../config/firebase.js';
 
 export const MINIMUM_WITHDRAWAL_AMOUNT = 50;
+export const WITHDRAWAL_FEE_PERCENTAGE = 0.1; // 10% fee
 
 export const createWithdrawalRequest = async (req: Request, res: Response) => {
   try {
@@ -19,6 +20,9 @@ export const createWithdrawalRequest = async (req: Request, res: Response) => {
         .status(400)
         .json({ error: `Minimum withdrawal amount is ₹${MINIMUM_WITHDRAWAL_AMOUNT}` });
     }
+
+    const fee = Math.round(numericAmount * WITHDRAWAL_FEE_PERCENTAGE * 100) / 100;
+    const netAmount = Math.round((numericAmount - fee) * 100) / 100;
 
     await db.runTransaction(async (transaction) => {
       const balanceRef = db.collection('balance').doc(userId);
@@ -44,6 +48,8 @@ export const createWithdrawalRequest = async (req: Request, res: Response) => {
       userId,
       userName: userName || '',
       amount: numericAmount,
+      fee,
+      netAmount,
       upiId,
       status: 'pending',
       requestDate: new Date().toISOString(),

--- a/src/components/withdrawal/WithdrawalForm.tsx
+++ b/src/components/withdrawal/WithdrawalForm.tsx
@@ -13,9 +13,10 @@ import { Input } from '@/components/ui/input';
 import { SanitizedInput } from '@/components/ui/sanitized-input';
 import { Button } from '@/components/ui/button';
 import { useMutation } from '@tanstack/react-query';
-import { 
+import {
   createWithdrawalRequest,
-  MINIMUM_WITHDRAWAL_AMOUNT
+  MINIMUM_WITHDRAWAL_AMOUNT,
+  WITHDRAWAL_FEE_PERCENTAGE
 } from '../../services/api/withdrawal';
 
 interface WithdrawalFormProps {
@@ -36,6 +37,10 @@ export function WithdrawalForm({
   const [amount, setAmount] = useState<string>('');
   const [upiId, setUpiId] = useState<string>('');
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
+
+  const amountValue = parseFloat(amount);
+  const feeAmount = isNaN(amountValue) ? 0 : amountValue * WITHDRAWAL_FEE_PERCENTAGE;
+  const netAmount = isNaN(amountValue) ? 0 : amountValue - feeAmount;
   
   const createWithdrawalMutation = useMutation({
     mutationFn: async () => {
@@ -119,7 +124,7 @@ export function WithdrawalForm({
           Withdraw Funds
         </CardTitle>
         <CardDescription>
-          Withdraw money to your UPI account (minimum ₹{MINIMUM_WITHDRAWAL_AMOUNT})
+          Withdraw money to your UPI account (minimum ₹{MINIMUM_WITHDRAWAL_AMOUNT}). A {(WITHDRAWAL_FEE_PERCENTAGE * 100).toFixed(0)}% fee will be deducted.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -137,6 +142,11 @@ export function WithdrawalForm({
               min={MINIMUM_WITHDRAWAL_AMOUNT}
               max={currentBalance > 0 ? currentBalance.toString() : '0'}
             />
+            {amount && !isNaN(amountValue) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                You will receive ₹{netAmount.toFixed(2)} after fees.
+              </p>
+            )}
           </div>
           <div>
             <label htmlFor="upiId" className="block text-sm font-medium text-muted-foreground mb-1">

--- a/src/services/api/withdrawal.ts
+++ b/src/services/api/withdrawal.ts
@@ -9,6 +9,8 @@ export interface WithdrawalRequest {
   userId: string;
   userName?: string;
   amount: number;
+  fee?: number;
+  netAmount?: number;
   upiId: string;
   status: 'pending' | 'completed' | 'rejected';
   requestDate: string;
@@ -19,6 +21,7 @@ export interface WithdrawalRequest {
 }
 
 export const MINIMUM_WITHDRAWAL_AMOUNT = 50;
+export const WITHDRAWAL_FEE_PERCENTAGE = 0.1;
 
 export const createWithdrawalRequest = async (
   userId: string,


### PR DESCRIPTION
## Summary
- add a constant for the withdrawal fee and compute net amount in the backend
- expose fee fields in the API service
- show a message about the fee and the net amount to the user when creating a withdrawal

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68824ee55f18832bada040736103e826