### PR TITLE
Implement daily top rankers leaderboard

### DIFF
--- a/backend/src/routes/dailyChallengeRoutes.ts
+++ b/backend/src/routes/dailyChallengeRoutes.ts
@@ -15,12 +15,14 @@ import {
   getChallengeStatus,
   getNextQuestion,
   submitAnswer,
+  getDailyRankings,
 } from '../controllers/challengeController.js';
 
 const router = express.Router();
 
 // Public list of active challenges
 router.get('/', getDailyChallenges);
+router.get('/top-rankers', getDailyRankings);
 
 // Authenticated user actions
 router.use(authenticateUser);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const SubCategories = React.lazy(() => import('./pages/SubCategories'));
 const AllMegaTests = React.lazy(() => import('./pages/AllMegaTests'));
 const DailyChallenges = React.lazy(() => import('./pages/DailyChallenges'));
 const DailyChallengePlay = React.lazy(() => import('./pages/DailyChallengePlay'));
+const DailyTopRankers = React.lazy(() => import('./pages/DailyTopRankers'));
 
 interface AuthContextProps {
   user: User | null;
@@ -90,6 +91,7 @@ const AppContent: React.FC = () => {
       <Route path="/all-mega-tests" element={<AllMegaTests />} />
       <Route path="/daily-challenges" element={<DailyChallenges />} />
       <Route path="/daily-challenges/:challengeId" element={<DailyChallengePlay />} />
+      <Route path="/daily-top-rankers" element={<DailyTopRankers />} />
       <Route path="/profile" element={
         <ProtectedRoute>
           <Profile />

--- a/src/pages/DailyTopRankers.tsx
+++ b/src/pages/DailyTopRankers.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { getDailyTopRankers, DailyRankEntry } from '@/services/api/dailyChallenge';
+import { getUserProfile } from '@/services/api/user';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { User } from 'lucide-react';
+
+interface RankEntry extends DailyRankEntry {
+  userName: string;
+}
+
+const DailyTopRankers = () => {
+  const navigate = useNavigate();
+  const { data } = useQuery<DailyRankEntry[]>({
+    queryKey: ['daily-top-rankers'],
+    queryFn: getDailyTopRankers,
+  });
+
+  const [entries, setEntries] = useState<RankEntry[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!data) return;
+      const withNames = await Promise.all(
+        data.map(async (e) => {
+          try {
+            const profile = await getUserProfile(e.userId);
+            return { ...e, userName: profile?.username || 'Anonymous' };
+          } catch {
+            return { ...e, userName: 'Anonymous' };
+          }
+        })
+      );
+      setEntries(withNames);
+    };
+    load();
+  }, [data]);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Button variant="ghost" className="mb-6" onClick={() => navigate(-1)}>
+        Back
+      </Button>
+      <Card>
+        <CardHeader>
+          <CardTitle>Daily Top Rankers</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {entries.map((entry, idx) => (
+              <div
+                key={entry.userId}
+                className="flex items-center justify-between p-2 rounded-md bg-muted/50"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-bold w-4 text-right">{idx + 1}.</span>
+                  <User className="h-4 w-4 text-muted-foreground" />
+                  <span>{entry.userName}</span>
+                </div>
+                <span className="font-medium">{entry.wins} wins</span>
+              </div>
+            ))}
+            {entries.length === 0 && (
+              <div className="text-center text-muted-foreground">No rankings yet</div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DailyTopRankers;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -339,6 +339,10 @@ const Home = () => {
                     <FileText className="h-4 w-4 mr-1" />
                     My Purchased Content
                   </Link>
+                  <Link to="/daily-top-rankers" className="text-sm font-medium hover:underline flex items-center">
+                    <Trophy className="h-4 w-4 mr-1 text-amber-500" />
+                    Daily Top Rankers
+                  </Link>
                   
                   {(isAdmin || isCustomAdmin) && (
                     <Link to="/admin" className="text-sm font-medium hover:underline flex items-center">
@@ -403,6 +407,12 @@ const Home = () => {
                       <Link to="/purchased-content" className="flex items-center">
                         <FileText className="h-4 w-4 mr-2" />
                         My Purchased Content
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link to="/daily-top-rankers" className="flex items-center">
+                        <Trophy className="h-4 w-4 mr-2 text-amber-500" />
+                        Daily Top Rankers
                       </Link>
                     </DropdownMenuItem>
                     
@@ -655,6 +665,7 @@ const Home = () => {
                 Daily Challenges
               </span>
               <Button variant="outline" size="sm" className="ml-2" onClick={() => navigate('/daily-challenges')}>All</Button>
+              <Button variant="outline" size="sm" className="ml-2" onClick={() => navigate('/daily-top-rankers')}>Top Rankers</Button>
               <div className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></div>
               <div className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-indigo-600/20 via-purple-600/20 to-pink-600/20 rounded-full"></div>
             </div>

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -36,6 +36,11 @@ export interface ChallengeQuestion {
   options: string[];
 }
 
+export interface DailyRankEntry {
+  userId: string;
+  wins: number;
+}
+
 export const getDailyChallenges = async (): Promise<DailyChallenge[]> => {
   const token = await getOptionalAuthToken();
   const res = await axios.get(`${API_URL}/api/daily-challenges`, {
@@ -182,5 +187,10 @@ export const adminGetQuestions = async (
 ): Promise<{ id: string; text: string; options: string[]; correctAnswer: string }[]> => {
   const api = await createAdminApi();
   const res = await api.get(`/api/daily-challenges/${challengeId}/questions`);
+  return res.data;
+};
+
+export const getDailyTopRankers = async (): Promise<DailyRankEntry[]> => {
+  const res = await axios.get(`${API_URL}/api/daily-challenges/top-rankers`);
   return res.data;
 };


### PR DESCRIPTION
## Summary
- track daily wins and expose `/daily-rankings` endpoint
- update challenge controller to record wins
- expose new route in dailyChallengeRoutes
- add API helper for top rankers
- create DailyTopRankers page and navigation links

## Testing
- `npm run lint` *(fails: 143 errors)*
- `cd backend && npm run lint` *(fails: invalid option)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68831c7c37c8832bb8237e02305b3733