### PR TITLE
Update daily top rankers logic

### DIFF
--- a/backend/src/utils/dailyRanking.ts
+++ b/backend/src/utils/dailyRanking.ts
@@ -1,0 +1,14 @@
+import { db } from '../config/firebase.js';
+import { FieldValue } from 'firebase-admin/firestore';
+
+export const recordDailyWinnings = async (userId: string, amount: number) => {
+  const date = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' });
+  const rankingRef = db.collection('daily-rankings').doc(date);
+  await rankingRef.set(
+    {
+      [userId]: FieldValue.increment(amount),
+      lastUpdated: new Date().toISOString(),
+    },
+    { merge: true },
+  );
+};

--- a/src/pages/DailyTopRankers.tsx
+++ b/src/pages/DailyTopRankers.tsx
@@ -59,7 +59,9 @@ const DailyTopRankers = () => {
                   <User className="h-4 w-4 text-muted-foreground" />
                   <span>{entry.userName}</span>
                 </div>
-                <span className="font-medium">{entry.wins} wins</span>
+                <span className="font-medium">
+                  ₹{entry.totalPrize.toLocaleString('en-IN')}
+                </span>
               </div>
             ))}
             {entries.length === 0 && (

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -38,7 +38,7 @@ export interface ChallengeQuestion {
 
 export interface DailyRankEntry {
   userId: string;
-  wins: number;
+  totalPrize: number;
 }
 
 export const getDailyChallenges = async (): Promise<DailyChallenge[]> => {


### PR DESCRIPTION
## Summary
- track cash prizes in daily rankings
- display daily top rankers by total prize amount
- include mega test prizes when recorded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `cd backend && npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688323d91d58832bab4802e3e347b39a