### PR TITLE
Fix mega test start and submit guards

### DIFF
--- a/backend/src/controllers/megaTestController.ts
+++ b/backend/src/controllers/megaTestController.ts
@@ -240,6 +240,11 @@ export const startMegaTest = async (req: Request, res: Response) => {
       .collection('participants')
       .doc(userId);
 
+    const existing = await participantRef.get();
+    if (existing.exists && (existing.data() as any).startTime) {
+      return res.status(400).json({ error: 'Mega test already started' });
+    }
+
     await participantRef.set(
       {
         startTime: new Date().toISOString(),
@@ -379,6 +384,10 @@ export const submitMegaTestResult = async (req: Request, res: Response) => {
     const megaTestRef = db.collection('mega-tests').doc(megaTestId);
     const leaderboardRef = megaTestRef.collection('leaderboard');
     const participantRef = megaTestRef.collection('participants').doc(userId);
+    const existingEntry = await leaderboardRef.doc(userId).get();
+    if (existingEntry.exists) {
+      return res.status(400).json({ error: 'Mega test already submitted' });
+    }
     const participantDoc = await participantRef.get();
 
     if (!participantDoc.exists || !(participantDoc.data() as any).startTime) {


### PR DESCRIPTION
## Summary
- prevent resetting `startTime` if mega test already started
- block resubmission after leaderboard entry exists

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883355c1aa8832bb459fc6cd20ac3aa