### PR TITLE
Adjust button placements on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -475,23 +475,23 @@ const Home = () => {
                 <Trophy className="h-6 w-6 mr-2 text-amber-500" />
                 MegaTests
               </h2>
-              <div className="flex items-center gap-2">
-                <Button
-                  onClick={() => navigate('/daily-top-rankers')}
-                  className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-purple-500 via-indigo-500 to-pink-500 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2"
-                  aria-label="Daily Top Rankers"
-                >
-                  Daily Top Rankers
-                </Button>
-                <Button
-                  onClick={() => navigate('/all-mega-tests')}
-                  className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-pink-400 focus:ring-offset-2"
-                  aria-label="View All Mega Tests"
-                >
-                  View All Mega Tests
-                  <ArrowUpRight className="h-4 w-4" />
-                </Button>
-              </div>
+              <Button
+                onClick={() => navigate('/all-mega-tests')}
+                className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-pink-400 focus:ring-offset-2"
+                aria-label="View All Mega Tests"
+              >
+                View All Mega Tests
+                <ArrowUpRight className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="flex justify-center mb-4">
+              <Button
+                onClick={() => navigate('/daily-top-rankers')}
+                className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-purple-500 via-indigo-500 to-pink-500 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2"
+                aria-label="Daily Top Rankers"
+              >
+                Daily Top Rankers
+              </Button>
             </div>
             <div className="relative">
               <div className="flex overflow-x-auto snap-x snap-mandatory scroll-smooth pb-4">
@@ -661,7 +661,7 @@ const Home = () => {
                 onClick={() => navigate('/daily-challenges')}
                 className="ml-2 flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-pink-400 focus:ring-offset-2"
               >
-                All
+                View All
               </Button>
               <div className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></div>
               <div className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-indigo-600/20 via-purple-600/20 to-pink-600/20 rounded-full"></div>


### PR DESCRIPTION
## Summary
- center "Daily Top Rankers" button above MegaTests cards for better layout
- rename Daily Challenges "All" button to "View All"

## Testing
- `npm run lint` *(fails: @typescript-eslint issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68833b1e1148832baf29b1f95951f082