### PR TITLE
Add spinner for DailyTopRankers

### DIFF
--- a/src/pages/DailyTopRankers.tsx
+++ b/src/pages/DailyTopRankers.tsx
@@ -6,6 +6,7 @@ import { getUserProfile } from '@/services/api/user';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { User } from 'lucide-react';
+import LoadingSpinner from '@/components/ui/loading-spinner';
 
 interface RankEntry extends DailyRankEntry {
   userName: string;
@@ -13,7 +14,7 @@ interface RankEntry extends DailyRankEntry {
 
 const DailyTopRankers = () => {
   const navigate = useNavigate();
-  const { data } = useQuery<DailyRankEntry[]>({
+  const { data, isLoading } = useQuery<DailyRankEntry[]>({
     queryKey: ['daily-top-rankers'],
     queryFn: getDailyTopRankers,
   });
@@ -37,6 +38,14 @@ const DailyTopRankers = () => {
     };
     load();
   }, [data]);
+
+  if (isLoading || (data && data.length > 0 && entries.length === 0)) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <LoadingSpinner className="h-8 w-8 text-primary" />
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- show loading spinner when fetching data for DailyTopRankers page

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68834914d8a8832b8d160b888adbf32e