### PR TITLE
Add AdSense admin management

### DIFF
--- a/backend/src/controllers/adsenseController.ts
+++ b/backend/src/controllers/adsenseController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { db } from '../config/firebase.js';
+
+export const getAdsenseConfig = async (_req: Request, res: Response) => {
+  try {
+    const docRef = db.collection('config').doc('adsense');
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return res.json({ enabled: false });
+    }
+    res.json(docSnap.data());
+  } catch (error) {
+    console.error('Error fetching adsense config:', error);
+    res.status(500).json({ error: 'Failed to fetch adsense config' });
+  }
+};

--- a/backend/src/routes/adsenseRoutes.ts
+++ b/backend/src/routes/adsenseRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getAdsenseConfig } from '../controllers/adsenseController.js';
+
+const router = express.Router();
+
+router.get('/', getAdsenseConfig);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -11,6 +11,7 @@ import paidContentRoutes from './paidContentRoutes.js';
 import dailyChallengeRoutes from './dailyChallengeRoutes.js';
 import withdrawalRoutes from './withdrawalRoutes.js';
 import settingsRoutes from './settingsRoutes.js';
+import adsenseRoutes from './adsenseRoutes.js';
 
 const router = express.Router();
 
@@ -38,6 +39,9 @@ router.use('/paid-contents', paidContentRoutes);
 
 // Site settings
 router.use('/settings', settingsRoutes);
+
+// AdSense config route
+router.use('/adsense', adsenseRoutes);
 
 // Daily challenge routes
 router.use('/daily-challenges', dailyChallengeRoutes);

--- a/src/components/AdsenseAd.tsx
+++ b/src/components/AdsenseAd.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getAdsenseConfig } from '@/services/api/adsense';
+
+interface AdsenseAdProps {
+  slotId?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+declare global {
+  interface Window {
+    adsbygoogle: unknown[];
+  }
+}
+
+const AdsenseAd = ({ slotId, className, style }: AdsenseAdProps) => {
+  const { data } = useQuery({ queryKey: ['adsense'], queryFn: getAdsenseConfig });
+
+  useEffect(() => {
+    if (!data?.enabled || !data.adClient) return;
+
+    const existing = document.getElementById('adsbygoogle-js');
+    if (!existing) {
+      const script = document.createElement('script');
+      script.id = 'adsbygoogle-js';
+      script.async = true;
+      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${data.adClient}`;
+      script.crossOrigin = 'anonymous';
+      document.head.appendChild(script);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    }
+  }, [data]);
+
+  if (!data?.enabled || !data.adClient || !data.adSlot) {
+    return null;
+  }
+
+  return (
+    <ins
+      className={`adsbygoogle ${className ?? ''}`}
+      style={style || { display: 'block' }}
+      data-ad-client={data.adClient}
+      data-ad-slot={slotId || data.adSlot}
+      data-ad-format="auto"
+      data-full-width-responsive="true"
+    />
+  );
+};
+
+export default AdsenseAd;

--- a/src/components/admin/AdsenseManager.tsx
+++ b/src/components/admin/AdsenseManager.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '@/services/firebase/config';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+const AdsenseManager = () => {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-adsense'],
+    queryFn: async () => {
+      const docRef = doc(db, 'config', 'adsense');
+      const snap = await getDoc(docRef);
+      if (snap.exists()) {
+        return snap.data() as { adClient?: string; adSlot?: string; enabled?: boolean };
+      }
+      return { adClient: '', adSlot: '', enabled: false };
+    }
+  });
+
+  const [adClient, setAdClient] = useState('');
+  const [adSlot, setAdSlot] = useState('');
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (data) {
+      setAdClient(data.adClient || '');
+      setAdSlot(data.adSlot || '');
+      setEnabled(!!data.enabled);
+    }
+  }, [data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: { adClient: string; adSlot: string; enabled: boolean }) => {
+      const docRef = doc(db, 'config', 'adsense');
+      await setDoc(docRef, payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-adsense'] });
+      queryClient.invalidateQueries({ queryKey: ['adsense'] });
+      toast.success('AdSense settings updated');
+    },
+    onError: error => {
+      console.error('Error updating adsense settings:', error);
+      toast.error('Failed to update AdSense settings');
+    }
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutation.mutate({ adClient, adSlot, enabled });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Google AdSense Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="ad-client">Ad Client ID</Label>
+            <Input id="ad-client" value={adClient} onChange={e => setAdClient(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ad-slot">Default Ad Slot</Label>
+            <Input id="ad-slot" value={adSlot} onChange={e => setAdSlot(e.target.value)} />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch id="ad-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            <Label htmlFor="ad-enabled">Enabled</Label>
+          </div>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AdsenseManager;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../App';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Flame, Wrench } from 'lucide-react';
+import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Flame, Wrench, BadgeDollarSign } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { AdminHeader } from '@/components/admin/AdminHeader';
@@ -13,6 +13,7 @@ import { TermsAndConditionsManager } from '../components/admin/TermsAndCondition
 import { AboutUsManager } from '../components/admin/AboutUsManager';
 import GuideManager from '../components/admin/GuideManager';
 import MaintenanceModeManager from '../components/admin/MaintenanceModeManager';
+import AdsenseManager from '../components/admin/AdsenseManager';
 import MegaTestManager from './admin/MegaTestManager';
 import QuestionPaperCategories from './admin/QuestionPaperCategories';
 import PaidContentManager from './admin/PaidContentManager';
@@ -135,6 +136,10 @@ const Admin = () => {
               <Wrench className="h-4 w-4" />
               <span>Maintenance</span>
             </TabsTrigger>
+            <TabsTrigger value="adsense" className="flex items-center gap-2">
+              <BadgeDollarSign className="h-4 w-4" />
+              <span>AdSense</span>
+            </TabsTrigger>
             <TabsTrigger value="guide" className="flex items-center gap-2">
               <Book className="h-4 w-4" />
               <span>Guide</span>
@@ -191,6 +196,10 @@ const Admin = () => {
 
           <TabsContent value="maintenance">
             <MaintenanceModeManager />
+          </TabsContent>
+
+          <TabsContent value="adsense">
+            <AdsenseManager />
           </TabsContent>
 
           <TabsContent value="guide">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,6 +18,7 @@ import { ModeToggle } from "../components/mode-toggle";
 import { logoutUser } from '../services/firebase/auth';
 import { LogOut, ShieldAlert, Trophy, Clock, ListChecks, CreditCard, Book, User, Menu, DollarSign, FileText, Loader2, ArrowUpRight } from 'lucide-react';
 import { format } from 'date-fns';
+import AdsenseAd from '../components/AdsenseAd';
 import LoadingSpinner from '../components/ui/loading-spinner';
 import { toast } from 'sonner';
 import MegaTestLeaderboard from "../components/MegaTestLeaderboard";
@@ -865,6 +866,10 @@ const Home = () => {
           </div>
         </div>
       </main>
+
+      <div className="my-4 flex justify-center">
+        <AdsenseAd />
+      </div>
 
       <footer className="py-6 border-t mt-auto">
         <div className="container mx-auto px-4 text-center text-muted-foreground">

--- a/src/services/api/adsense.ts
+++ b/src/services/api/adsense.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export interface AdsenseConfig {
+  adClient?: string;
+  adSlot?: string;
+  enabled?: boolean;
+}
+
+export const getAdsenseConfig = async (): Promise<AdsenseConfig> => {
+  const res = await axios.get(`${API_URL}/api/adsense`);
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- allow backend to serve AdSense config
- expose API to fetch AdSense config
- add AdSenseManager component for admins
- load ads with new AdsenseAd component
- display ads on homepage
- wire up new AdSense tab in Admin panel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883aa4f927c832ba406f504c7693881