### PR TITLE
Add SEO manager and meta tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react-dom": "^18.3.1",
         "react-firebase-hooks": "^5.1.1",
         "react-gtm-module": "^2.0.11",
+        "react-helmet": "^6.1.0",
         "react-hook-form": "^7.53.0",
         "react-hot-toast": "^2.5.2",
         "react-intersection-observer": "^9.16.0",
@@ -8404,6 +8405,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
     "node_modules/react-firebase-hooks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.1.1.tgz",
@@ -8419,6 +8426,21 @@
       "resolved": "https://registry.npmjs.org/react-gtm-module/-/react-gtm-module-2.0.11.tgz",
       "integrity": "sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==",
       "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
     },
     "node_modules/react-hook-form": {
       "version": "7.53.1",
@@ -8584,6 +8606,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
     "vaul": "^0.9.3",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
 import { app } from './services/firebase/config';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
+import Seo from './components/Seo';
 import { useSessionTimeout } from './hooks/useSessionTimeout';
 import { useSingleTabEnforcer } from './hooks/useSingleTabEnforcer';
 import { initializeGTM } from './services/gtm';
@@ -219,6 +220,7 @@ const App: React.FC = () => {
       <AuthProvider>
         <Router>
           <Toaster position="bottom-center" richColors />
+          <Seo />
           <AppContent />
         </Router>
       </AuthProvider>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,25 @@
+import { Helmet } from 'react-helmet';
+import { useQuery } from '@tanstack/react-query';
+import { getSettings } from '@/services/api/settings';
+
+const Seo = () => {
+  const { data: settings } = useQuery({
+    queryKey: ['settings'],
+    queryFn: getSettings
+  });
+
+  return (
+    <Helmet>
+      {settings?.seoTitle && <title>{settings.seoTitle}</title>}
+      {settings?.seoDescription && (
+        <meta name="description" content={settings.seoDescription} />
+      )}
+      {settings?.seoKeywords && (
+        <meta name="keywords" content={settings.seoKeywords} />
+      )}
+    </Helmet>
+  );
+};
+
+export default Seo;
+

--- a/src/components/admin/SEOManager.tsx
+++ b/src/components/admin/SEOManager.tsx
@@ -1,0 +1,134 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../../services/firebase/config';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+const SEOManager = () => {
+  const queryClient = useQueryClient();
+  const [formState, setFormState] = useState({
+    seoTitle: '',
+    seoDescription: '',
+    seoKeywords: ''
+  });
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ['admin-seo-settings'],
+    queryFn: async () => {
+      const docRef = doc(db, 'config', 'settings');
+      const snap = await getDoc(docRef);
+      if (snap.exists()) {
+        return snap.data() as {
+          seoTitle?: string;
+          seoDescription?: string;
+          seoKeywords?: string;
+        };
+      }
+      return { seoTitle: '', seoDescription: '', seoKeywords: '' };
+    }
+  });
+
+  useEffect(() => {
+    if (settings) {
+      setFormState({
+        seoTitle: settings.seoTitle || '',
+        seoDescription: settings.seoDescription || '',
+        seoKeywords: settings.seoKeywords || ''
+      });
+    }
+  }, [settings]);
+
+  const mutation = useMutation({
+    mutationFn: async (data: typeof formState) => {
+      const docRef = doc(db, 'config', 'settings');
+      await setDoc(docRef, data, { merge: true });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-seo-settings'] });
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('SEO settings updated');
+    },
+    onError: (err) => {
+      console.error('Error updating SEO settings:', err);
+      toast.error('Failed to update SEO settings');
+    }
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormState(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutation.mutate(formState);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>SEO Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="seoTitle" className="text-sm font-medium">
+              Site Title
+            </label>
+            <Input
+              id="seoTitle"
+              name="seoTitle"
+              value={formState.seoTitle}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="seoDescription" className="text-sm font-medium">
+              Meta Description
+            </label>
+            <Textarea
+              id="seoDescription"
+              name="seoDescription"
+              value={formState.seoDescription}
+              onChange={handleChange}
+              className="min-h-[120px]"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="seoKeywords" className="text-sm font-medium">
+              Keywords
+            </label>
+            <Input
+              id="seoKeywords"
+              name="seoKeywords"
+              value={formState.seoKeywords}
+              onChange={handleChange}
+            />
+          </div>
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Update SEO Settings
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SEOManager;
+

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../App';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Flame, Wrench } from 'lucide-react';
+import { Users, BookOpen, Wallet, Trophy, FileText, ScrollText, Info, Book, FileArchive, DollarSign, Flame, Wrench, Search } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { AdminHeader } from '@/components/admin/AdminHeader';
@@ -17,6 +17,7 @@ import MegaTestManager from './admin/MegaTestManager';
 import QuestionPaperCategories from './admin/QuestionPaperCategories';
 import PaidContentManager from './admin/PaidContentManager';
 import DailyChallengeManager from './admin/DailyChallengeManager';
+import SEOManager from '../components/admin/SEOManager';
 import { WithdrawalManagement } from '../components/admin/WithdrawalManagement';
 import { getAllUsers, getAllBalances } from '@/services/api/admin';
 import { db } from '@/services/firebase/config';
@@ -131,6 +132,10 @@ const Admin = () => {
               <Info className="h-4 w-4" />
               <span>About Us</span>
             </TabsTrigger>
+            <TabsTrigger value="seo" className="flex items-center gap-2">
+              <Search className="h-4 w-4" />
+              <span>SEO</span>
+            </TabsTrigger>
             <TabsTrigger value="maintenance" className="flex items-center gap-2">
               <Wrench className="h-4 w-4" />
               <span>Maintenance</span>
@@ -187,6 +192,10 @@ const Admin = () => {
 
           <TabsContent value="about-us">
             <AboutUsManager />
+          </TabsContent>
+
+          <TabsContent value="seo">
+            <SEOManager />
           </TabsContent>
 
           <TabsContent value="maintenance">

--- a/src/services/api/settings.ts
+++ b/src/services/api/settings.ts
@@ -4,6 +4,9 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export interface SiteSettings {
   maintenanceMode?: boolean;
+  seoTitle?: string;
+  seoDescription?: string;
+  seoKeywords?: string;
 }
 
 export const getSettings = async (): Promise<SiteSettings> => {


### PR DESCRIPTION
## Summary
- allow editing SEO settings in admin panel
- store SEO fields via Firestore
- use new Seo component to inject meta tags
- add react-helmet dependency

## Testing
- `npm run lint` *(fails: no-useless-catch, no-explicit-any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883b69c1b10832ba47529bc4ee52600