### PR TITLE
Use slug-based question paper URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,7 +172,7 @@ const AppContent: React.FC = () => {
       } />
       {/* Question Paper Routes */}
       <Route path="/question-papers" element={<QuestionPapers />} />
-      <Route path="/question-papers/:categoryId" element={<QuestionPaperCategory />} />
+      <Route path="/question-papers/:categorySlug" element={<QuestionPaperCategory />} />
       <Route path="/admin/question-paper-categories" element={
         <ProtectedRoute>
           <AdminQuestionPaperCategories />

--- a/src/pages/QuestionPapers.tsx
+++ b/src/pages/QuestionPapers.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { slugify } from '../utils/slugify';
 import { getQuestionPaperCategories } from '../services/api/questionPapers';
 import type { QuestionPaperCategory } from '../services/api/questionPapers';
 import { ArrowLeft, BookOpen, Download, Users, Clock, Star, TrendingUp } from 'lucide-react';
@@ -95,9 +96,9 @@ export default function QuestionPapers() {
               </div>
             </CardContent>
             <CardFooter className="p-3 md:p-6 pt-0">
-              <Button 
+              <Button
                 className="w-full group-hover:bg-blue-600 transition-colors text-sm md:text-base"
-                onClick={() => navigate(`/question-papers/${category.id}`)}
+                onClick={() => navigate(`/question-papers/${slugify(category.title)}`)}
               >
                 <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
                 View Papers

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,0 +1,7 @@
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Summary
- make question paper category URLs SEO friendly using name slugs
- add a slugify utility

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68847aca8a40832ba2ae3b119c11e68b