### PR TITLE
Update question paper endpoint

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -27,7 +27,7 @@ router.use('/payments', paymentRoutes);
 router.use('/quiz', quizRoutes);
 
 // Question paper routes
-router.use('/question-papers', questionPaperRoutes);
+router.use('/pyqs', questionPaperRoutes);
 
 // Mega test routes
 router.use('/mega-tests', megaTestRoutes);

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -72,7 +72,7 @@
 
   <!-- Question Papers -->
   <url>
-    <loc>https://rajtest.com/question-papers</loc>
+    <loc>https://rajtest.com/pyqs</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -152,7 +152,7 @@
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://rajtest.com/admin/question-papers</loc>
+    <loc>https://rajtest.com/admin/pyqs</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,14 +171,14 @@ const AppContent: React.FC = () => {
         </ProtectedRoute>
       } />
       {/* Question Paper Routes */}
-      <Route path="/question-papers" element={<QuestionPapers />} />
-      <Route path="/question-papers/:categorySlug" element={<QuestionPaperCategory />} />
+      <Route path="/pyqs" element={<QuestionPapers />} />
+      <Route path="/pyqs/:categorySlug" element={<QuestionPaperCategory />} />
       <Route path="/admin/question-paper-categories" element={
         <ProtectedRoute>
           <AdminQuestionPaperCategories />
         </ProtectedRoute>
       } />
-      <Route path="/admin/question-papers/:categoryId" element={
+      <Route path="/admin/pyqs/:categoryId" element={
         <ProtectedRoute>
           <AdminQuestionPapers />
         </ProtectedRoute>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -336,7 +336,7 @@ const Home = () => {
                     <Book className="h-4 w-4 mr-1" />
                     Guide
                   </Link>
-                  <Link to="/question-papers" className="text-sm font-medium hover:underline flex items-center">
+                  <Link to="/pyqs" className="text-sm font-medium hover:underline flex items-center">
                     <Book className="h-4 w-4 mr-1" />
                     PYQs
                   </Link>
@@ -403,7 +403,7 @@ const Home = () => {
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
-                      <Link to="/question-papers" className="flex items-center">
+                      <Link to="/pyqs" className="flex items-center">
                         <Book className="h-4 w-4 mr-2" />
                         PYQs
                       </Link>

--- a/src/pages/QuestionPaperCategory.tsx
+++ b/src/pages/QuestionPaperCategory.tsx
@@ -75,7 +75,7 @@ export default function QuestionPaperCategory() {
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => navigate('/question-papers')}
+          onClick={() => navigate('/pyqs')}
           className="hover:bg-gray-100 dark:hover:bg-gray-800"
         >
           <ArrowLeft className="h-5 w-5" />

--- a/src/pages/QuestionPapers.tsx
+++ b/src/pages/QuestionPapers.tsx
@@ -98,7 +98,7 @@ export default function QuestionPapers() {
             <CardFooter className="p-3 md:p-6 pt-0">
               <Button
                 className="w-full group-hover:bg-blue-600 transition-colors text-sm md:text-base"
-                onClick={() => navigate(`/question-papers/${slugify(category.title)}`)}
+                onClick={() => navigate(`/pyqs/${slugify(category.title)}`)}
               >
                 <Download className="h-3 w-3 md:h-4 md:w-4 mr-1 md:mr-2" />
                 View Papers

--- a/src/pages/admin/QuestionPaperCategories.tsx
+++ b/src/pages/admin/QuestionPaperCategories.tsx
@@ -190,7 +190,7 @@ export default function QuestionPaperCategories() {
                 <p className="text-gray-600 mb-4">{category.description}</p>
                 <div className="flex justify-between items-center">
                   <Link
-                    to={`/admin/question-papers/${category.id}`}
+                    to={`/admin/pyqs/${category.id}`}
                     className="text-blue-500 hover:text-blue-700"
                   >
                     Manage Papers

--- a/src/services/api/questionPapers.ts
+++ b/src/services/api/questionPapers.ts
@@ -23,7 +23,7 @@ export interface QuestionPaper {
 
 export const getQuestionPaperCategories = async (): Promise<QuestionPaperCategory[]> => {
   const token = await getOptionalAuthToken();
-  const res = await axios.get(`${API_URL}/api/question-papers/categories`, {
+  const res = await axios.get(`${API_URL}/api/pyqs/categories`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {}
   });
   return res.data;
@@ -32,7 +32,7 @@ export const getQuestionPaperCategories = async (): Promise<QuestionPaperCategor
 export const getQuestionPapersByCategory = async (categoryId: string): Promise<QuestionPaper[]> => {
   const token = await getOptionalAuthToken();
   const res = await axios.get(
-    `${API_URL}/api/question-papers/categories/${categoryId}/papers`,
+    `${API_URL}/api/pyqs/categories/${categoryId}/papers`,
     { headers: token ? { Authorization: `Bearer ${token}` } : {} }
   );
   return res.data;


### PR DESCRIPTION
## Summary
- rename `/question-papers` endpoint to `/pyqs`
- update frontend routes and API service
- update sitemap links

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `cd backend && npm run lint` *(fails: invalid option --ext)*

------
https://chatgpt.com/codex/tasks/task_e_68847dff703c832b97b4a855305a66be