### PR TITLE
Switch quiz routes to use slugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,12 +135,12 @@ const AppContent: React.FC = () => {
           <QuizCategories />
         </ProtectedRoute>
       } />
-      <Route path="/category/:categoryId/subcategories" element={
+      <Route path="/category/:categorySlug/subcategories" element={
         <ProtectedRoute>
           <SubCategories />
         </ProtectedRoute>
       } />
-      <Route path="/category/:categoryId/subcategory/:subcategoryId/quizzes" element={
+      <Route path="/category/:categorySlug/subcategory/:subcategorySlug/quizzes" element={
         <ProtectedRoute>
           <CategoryQuizzes />
         </ProtectedRoute>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { getMegaTests, registerForMegaTest, isUserRegistered, hasUserSubmittedMe
 import { getMegaTestQuestionCount } from '@/services/firebase/quiz';
 import { getDailyChallenges, DailyChallenge, startChallenge, getChallengeStatus } from '../services/api/dailyChallenge';
 import { parseTimestamp } from '@/utils/parseTimestamp';
+import { slugify } from '@/utils/slugify';
 import { AuthContext } from '../App';
 import { Card } from "@/components/ui/card";
 import { CardContent } from "@/components/ui/card";
@@ -849,7 +850,11 @@ const Home = () => {
                       <Button 
                         className="w-full bg-blue-600 hover:bg-blue-700 text-white transition-colors duration-300" 
                         variant="default"
-                        onClick={() => !isAuthenticated ? navigate('/auth') : navigate(`/category/${category.id}/subcategories`)}
+                        onClick={() =>
+                          !isAuthenticated
+                            ? navigate('/auth')
+                            : navigate(`/category/${slugify(category.title)}/subcategories`)
+                        }
                       >
                         {!isAuthenticated ? 'Sign in to Browse' : 'Browse Quizzes'}
                       </Button>

--- a/src/pages/QuizCategories.tsx
+++ b/src/pages/QuizCategories.tsx
@@ -6,6 +6,7 @@ import { getQuizCategories } from '@/services/api/quiz';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { slugify } from '@/utils/slugify';
 
 const QuizCategories = () => {
   const navigate = useNavigate();
@@ -59,7 +60,9 @@ const QuizCategories = () => {
           <Card
             key={category.id}
             className="hover:shadow-lg transition-shadow cursor-pointer"
-            onClick={() => navigate(`/category/${category.id}/subcategories`)}
+            onClick={() =>
+              navigate(`/category/${slugify(category.title)}/subcategories`)
+            }
           >
             <CardHeader>
               <CardTitle>{category.title}</CardTitle>


### PR DESCRIPTION
## Summary
- use slugified category and subcategory names for quiz URLs
- update router and navigation helpers for slug paths
- fetch category and subcategory info in quiz page to build slugs

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688484f4328c832b8e0727b3c61aea2a