### PR TITLE
Fix daily challenge MCQ left count

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -281,9 +281,15 @@ export const getChallengeStatus = async (req: Request, res: Response) => {
     const challengeDoc = await db.collection('daily-challenges').doc(challengeId).get();
     const challenge = challengeDoc.data() as any;
     const timeLimit = challengeDoc.exists ? challenge.timeLimit : 0;
+    const questionSnap = await db
+      .collection('daily-challenges')
+      .doc(challengeId)
+      .collection('questions')
+      .get();
+    const totalQuestions = questionSnap.size;
 
     if (!entryDoc.exists) {
-      return res.json({ started: false, timeLimit });
+      return res.json({ started: false, timeLimit, totalQuestions });
     }
 
     const entryRef = db.collection('daily-challenge-entries').doc(entryId);
@@ -292,7 +298,7 @@ export const getChallengeStatus = async (req: Request, res: Response) => {
       entryDoc.data() as ChallengeEntry,
       challenge,
     );
-    res.json({ started: true, ...updatedEntry, timeLimit });
+    res.json({ started: true, ...updatedEntry, timeLimit, totalQuestions });
   } catch (error) {
     console.error('Error getting status:', error);
     res.status(500).json({ error: 'Failed to get status' });
@@ -487,6 +493,7 @@ export const submitAnswer = async (req: Request, res: Response) => {
       completed,
       won,
       timeLimit,
+      totalQuestions,
       nextQuestion,
     });
   } catch (error) {

--- a/src/pages/DailyChallengePlay.tsx
+++ b/src/pages/DailyChallengePlay.tsx
@@ -167,7 +167,10 @@ const DailyChallengePlay = () => {
                       MCQ {currentIndex}
                     </div>
                     <div className="text-xs font-medium bg-muted px-2 py-0.5 rounded-full">
-                      Left: {Math.max(0, challengeInfo.requiredCorrect - currentIndex)}
+                      {(() => {
+                        const total = status?.totalQuestions ?? challengeInfo.requiredCorrect;
+                        return `Left: ${Math.max(0, total - currentIndex)}`;
+                      })()}
                     </div>
                   </>
                 )}

--- a/src/services/api/dailyChallenge.ts
+++ b/src/services/api/dailyChallenge.ts
@@ -28,6 +28,7 @@ export interface ChallengeStatus {
   startedAt?: string;
   completedAt?: string;
   timeLimit: number;
+  totalQuestions?: number;
 }
 
 export interface ChallengeQuestion {


### PR DESCRIPTION
## Summary
- include total question count in daily challenge status and submission APIs
- show MCQs left based on total question count

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68848f50b7c4832b8da1e35696ae9c4e