### PR TITLE
Disable polling on leaderboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,8 @@ const AppContent: React.FC = () => {
   const { data: settings, isLoading: settingsLoading } = useQuery({
     queryKey: ['settings'],
     queryFn: getSettings,
-    refetchInterval: 60000
+    refetchOnWindowFocus: false,
+    staleTime: 60 * 1000,
   });
 
   const handleLogout = () => {

--- a/src/components/MegaTestLeaderboard.tsx
+++ b/src/components/MegaTestLeaderboard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
-import { Trophy, Medal, User, Search, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Trophy, Medal, User, Search, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
 import { MegaTestLeaderboardEntry } from '../services/api/megaTest';
 import { getMegaTestLeaderboard } from '../services/api/megaTest';
 import { useQuery } from '@tanstack/react-query';
@@ -39,7 +39,9 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
 
       return entriesWithUserDetails.sort((a, b) => a.rank - b.rank);
     },
-    refetchInterval: 5000, // Refetch every 5 seconds for polling
+    // Disable automatic polling to avoid continuous requests
+    refetchOnWindowFocus: false,
+    staleTime: 60 * 1000,
   });
 
   const getRankIcon = (rank: number) => {
@@ -91,7 +93,7 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
     <Card className="w-full">
       <CardHeader>
         <CardTitle>Leaderboard</CardTitle>
-        <div className="relative">
+        <div className="relative flex items-center gap-2">
           <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
             placeholder="Search by name..."
@@ -99,6 +101,9 @@ const MegaTestLeaderboard = ({ megaTestId, standalone = false }: MegaTestLeaderb
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-8"
           />
+          <Button variant="outline" size="icon" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4" />
+          </Button>
         </div>
         {currentUserRank && (
           <div className="text-sm text-muted-foreground">

--- a/src/components/MegaTestParticipantsProgress.tsx
+++ b/src/components/MegaTestParticipantsProgress.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { RefreshCw } from 'lucide-react';
 import { getMegaTestParticipantCount } from '@/services/api/megaTest';
 
 interface MegaTestParticipantsProgressProps {
@@ -8,10 +10,11 @@ interface MegaTestParticipantsProgressProps {
 }
 
 const MegaTestParticipantsProgress = ({ megaTestId, maxParticipants }: MegaTestParticipantsProgressProps) => {
-  const { data: count } = useQuery({
+  const { data: count, refetch } = useQuery({
     queryKey: ['participant-count', megaTestId],
     queryFn: () => getMegaTestParticipantCount(megaTestId),
-    refetchInterval: 5000,
+    refetchOnWindowFocus: false,
+    staleTime: 60 * 1000,
   });
 
   if (!maxParticipants || maxParticipants <= 0) return null;
@@ -34,6 +37,9 @@ const MegaTestParticipantsProgress = ({ megaTestId, maxParticipants }: MegaTestP
         >
           {remaining > 0 ? `${remaining} seats left` : 'Seats full'}
         </span>
+        <Button variant="ghost" size="icon" onClick={() => refetch()}>
+          <RefreshCw className="h-3 w-3" />
+        </Button>
       </div>
       <Progress value={percentage} className="h-2 rounded-full bg-muted" />
     </div>


### PR DESCRIPTION
## Summary
- remove automatic polling from mega test leaderboard and participants progress
- add manual refresh buttons to update on demand
- stop polling settings from the app component

## Testing
- `npm run lint` *(fails: 165 problems)*
- `npx eslint src/App.tsx src/components/MegaTestLeaderboard.tsx src/components/MegaTestParticipantsProgress.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688492454858832b9a382160dd2bf77e