### PR TITLE
Add SEO-friendly quiz endpoints

### DIFF
--- a/backend/src/routes/quizRoutes.ts
+++ b/backend/src/routes/quizRoutes.ts
@@ -9,8 +9,10 @@ import {
 const router = express.Router();
 
 router.get('/categories', getQuizCategories);
-router.get('/categories/:categoryId/sub-categories', getSubCategories);
-router.get('/quizzes', getQuizzesByCategory);
+router.get('/categories/:categoryIdentifier/sub-categories', getSubCategories);
+router.get('/categories/:categoryIdentifier/quizzes', getQuizzesByCategory);
+router.get('/categories/:categoryIdentifier/subcategories/:subcategoryIdentifier/quizzes', getQuizzesByCategory);
+router.get('/quizzes', getQuizzesByCategory); // legacy query based
 router.get('/quizzes/:quizId', getQuizById);
 
 export default router;

--- a/backend/src/utils/slugify.ts
+++ b/backend/src/utils/slugify.ts
@@ -1,0 +1,7 @@
+export const slugify = (text: string): string => {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -79,7 +79,7 @@
 
   <!-- Category Quizzes -->
   <url>
-    <loc>https://rajtest.com/category-quizzes</loc>
+    <loc>https://rajtest.com/quizzes</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,12 +136,22 @@ const AppContent: React.FC = () => {
           <QuizCategories />
         </ProtectedRoute>
       } />
-      <Route path="/category/:categoryId/subcategories" element={
+      <Route path="/category/:categorySlug/subcategories" element={
         <ProtectedRoute>
           <SubCategories />
         </ProtectedRoute>
       } />
-      <Route path="/category/:categoryId/subcategory/:subcategoryId/quizzes" element={
+      <Route path="/category/:categorySlug/subcategory/:subcategorySlug/quizzes" element={
+        <ProtectedRoute>
+          <CategoryQuizzes />
+        </ProtectedRoute>
+      } />
+      <Route path="/quizzes/:categorySlug" element={
+        <ProtectedRoute>
+          <CategoryQuizzes />
+        </ProtectedRoute>
+      } />
+      <Route path="/quizzes/:categorySlug/:subcategorySlug" element={
         <ProtectedRoute>
           <CategoryQuizzes />
         </ProtectedRoute>

--- a/src/pages/QuizCategories.tsx
+++ b/src/pages/QuizCategories.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Loader2, Search } from 'lucide-react';
 import { getQuizCategories } from '@/services/api/quiz';
+import { slugify } from '@/utils/slugify';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -59,7 +60,7 @@ const QuizCategories = () => {
           <Card
             key={category.id}
             className="hover:shadow-lg transition-shadow cursor-pointer"
-            onClick={() => navigate(`/category/${category.id}/subcategories`)}
+            onClick={() => navigate(`/category/${slugify(category.title)}/subcategories`)}
           >
             <CardHeader>
               <CardTitle>{category.title}</CardTitle>

--- a/src/pages/SubCategories.tsx
+++ b/src/pages/SubCategories.tsx
@@ -4,23 +4,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Loader2, Search } from 'lucide-react';
 import { getSubCategories, getQuizCategories } from '@/services/api/quiz';
+import { slugify } from '@/utils/slugify';
 import { Input } from '@/components/ui/input';
 import { useState } from 'react';
 
 const SubCategories = () => {
-  const { categoryId } = useParams();
+  const { categorySlug } = useParams();
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
   const [visibleSubCategories, setVisibleSubCategories] = useState(10);
 
-  const { data: category } = useQuery({
-    queryKey: ['quiz-category', categoryId],
-    queryFn: async () => {
-      const categories = await getQuizCategories();
-      return categories.find(cat => cat.id === categoryId);
-    },
-    enabled: !!categoryId
+  const { data: categories = [] } = useQuery({
+    queryKey: ['quiz-categories'],
+    queryFn: getQuizCategories
   });
+
+  const category = categories.find(cat => slugify(cat.title) === categorySlug || cat.id === categorySlug);
+  const categoryId = category?.id;
 
   const { data: subCategories = [], isLoading } = useQuery({
     queryKey: ['sub-categories', categoryId],
@@ -92,7 +92,7 @@ const SubCategories = () => {
           <Card
             key={subCategory.id}
             className="overflow-hidden hover:shadow-lg transition-all duration-300 border-2 hover:border-blue-400 bg-gradient-to-br from-white to-blue-50 dark:from-gray-900 dark:to-gray-800"
-            onClick={() => navigate(`/category/${categoryId}/subcategory/${subCategory.id}/quizzes`)}
+            onClick={() => navigate(`/category/${categorySlug}/subcategory/${slugify(subCategory.title)}/quizzes`)}
           >
             <CardHeader className="pb-2 space-y-1 sm:space-y-2">
               <CardTitle className="text-base sm:text-lg font-semibold text-blue-700 dark:text-blue-400 break-words">{subCategory.title}</CardTitle>

--- a/src/services/api/quiz.ts
+++ b/src/services/api/quiz.ts
@@ -49,13 +49,14 @@ export const getSubCategories = async (categoryId: string): Promise<SubCategory[
 };
 
 export const getQuizzesByCategory = async (
-  categoryId: string,
-  subcategoryId?: string
+  category: string,
+  subcategory?: string
 ): Promise<Quiz[]> => {
   const token = await getOptionalAuthToken();
-  const params = new URLSearchParams({ categoryId });
-  if (subcategoryId) params.append('subcategoryId', subcategoryId);
-  const res = await axios.get(`${API_URL}/api/quiz/quizzes?${params.toString()}`, {
+  const url = subcategory
+    ? `${API_URL}/api/quiz/categories/${category}/subcategories/${subcategory}/quizzes`
+    : `${API_URL}/api/quiz/categories/${category}/quizzes`;
+  const res = await axios.get(url, {
     headers: token ? { Authorization: `Bearer ${token}` } : {}
   });
   return res.data;


### PR DESCRIPTION
## Summary
- add slugify util to backend
- extend quiz controller to accept slug-based params
- expose new REST routes for SEO-friendly paths
- update frontend API calls to use slug paths
- update routing to support category and subcategory slugs
- adjust pages to navigate via slugs
- refresh sitemap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68849d0a0698832b92b3ddfa88084dd1