### PR TITLE
Fix Razorpay webhook signature verification

### DIFF
--- a/backend/src/controllers/paymentController.ts
+++ b/backend/src/controllers/paymentController.ts
@@ -206,14 +206,14 @@ export const razorpayWebhook = async (req: Request, res: Response) => {
     return res.status(500).json({ error: 'Webhook service not configured' });
   }
 
-  // Verify webhook signature
+  // Verify webhook signature using the raw request body
   const signature = req.headers['x-razorpay-signature'] as string;
-  const body = JSON.stringify(req.body);
+  const bodyBuffer = req.body as Buffer;
 
   try {
     const expectedSignature = crypto
       .createHmac('sha256', razorpayWebhookSecret)
-      .update(body)
+      .update(bodyBuffer)
       .digest('hex');
 
     if (expectedSignature !== signature) {
@@ -226,7 +226,7 @@ export const razorpayWebhook = async (req: Request, res: Response) => {
   }
 
   // Process the event
-  const event = req.body;
+  const event = JSON.parse(bodyBuffer.toString());
   if (event.event === 'payment.captured') {
     const paymentEntity = event.payload.payment.entity;
     const { order_id, id: paymentId, amount, notes } = paymentEntity;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,8 @@ app.use(cors({
 }));
 app.use(helmet());
 app.use(morgan('dev'));
+// Parse Razorpay webhook requests as raw body before JSON parsing
+app.use('/api/payments/webhook', express.raw({ type: 'application/json' }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/backend/src/routes/paymentRoutes.ts
+++ b/backend/src/routes/paymentRoutes.ts
@@ -11,7 +11,7 @@ router.post('/create-order', authenticateUser, createPaymentOrder);
 router.post('/verify', authenticateUser, verifyPayment);
 
 // Razorpay webhook endpoint (No user auth - secured by signature verification)
-// This endpoint receives server-to-server updates from Razorpay
-router.post('/webhook', express.json(), razorpayWebhook);
+// Use express.raw to obtain the raw body for signature verification
+router.post('/webhook', express.raw({ type: 'application/json' }), razorpayWebhook);
 
 export default router;


### PR DESCRIPTION
## Summary
- ensure webhook route gets raw body for Razorpay signature check
- compute Razorpay webhook signature from raw request body

## Testing
- `npm run build` *(fails: Property 'COOKIE_DOMAIN' does not exist)*
- `npx tsc --noEmit src/controllers/paymentController.ts` *(fails: Private identifiers not allowed when targeting ES5)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6884be653bf8832b91bac44d72ad1bbb