### PR TITLE
Add expiry cleanup for daily challenges

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "crypto": "^1.0.1",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
@@ -21,6 +22,7 @@
         "helmet": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "node-cron": "^4.2.1",
         "razorpay": "2.8.6",
         "zod": "^3.24.3"
       },
@@ -2642,6 +2644,26 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4894,6 +4916,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
@@ -24,6 +25,7 @@
     "helmet": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "node-cron": "^4.2.1",
     "razorpay": "2.8.6",
     "zod": "^3.24.3"
   },

--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -11,6 +11,7 @@ interface ChallengeEntry {
   completed: boolean;
   won: boolean;
   startedAt: string;
+  expiresAt: string;
   completedAt?: string;
 }
 
@@ -255,6 +256,14 @@ export const startChallenge = async (req: Request, res: Response) => {
       completed: false,
       won: false,
       startedAt: new Date().toISOString(),
+      expiresAt: (() => {
+        const now = new Date();
+        const istString = now.toLocaleString('en-US', { timeZone: 'Asia/Kolkata' });
+        const istDate = new Date(istString);
+        istDate.setHours(23, 59, 0, 0);
+        const expires = new Date(istDate.toLocaleString('en-US', { timeZone: 'UTC' }));
+        return expires.toISOString();
+      })(),
     };
     await entryRef.set(entry);
     res.json({ success: true });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import routes from './routes/index.js';
 import './config/firebase.js';
+import { scheduleDailyChallengeCleanup } from './scheduler/cleanupEntries.js';
 
 // Load environment variables
 dotenv.config();
@@ -30,6 +31,9 @@ app.use(express.urlencoded({ extended: true }));
 
 // Routes
 app.use('/api', routes);
+
+// Schedule daily cleanup of expired challenge entries
+scheduleDailyChallengeCleanup();
 
 // Basic health check route
 app.get('/health', (req, res) => {

--- a/backend/src/scheduler/cleanupEntries.ts
+++ b/backend/src/scheduler/cleanupEntries.ts
@@ -1,0 +1,18 @@
+import cron from 'node-cron';
+import { db } from '../config/firebase.js';
+
+export const scheduleDailyChallengeCleanup = () => {
+  cron.schedule('59 23 * * *', async () => {
+    const now = new Date();
+    const snapshot = await db
+      .collection('daily-challenge-entries')
+      .where('expiresAt', '<=', now)
+      .get();
+    const batch = db.batch();
+    snapshot.docs.forEach(doc => batch.delete(doc.ref));
+    if (!snapshot.empty) {
+      await batch.commit();
+      console.log(`Cleaned up ${snapshot.size} expired challenge entries`);
+    }
+  }, { timezone: 'Asia/Kolkata' });
+};


### PR DESCRIPTION
## Summary
- add scheduler to clean up expired daily challenge entries
- expire daily challenge entries at 11:59pm IST on creation
- wire scheduler into server startup
- install `date-fns-tz` and `node-cron` for timezone handling

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build` *(fails: Property 'COOKIE_DOMAIN' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6884c3d82024832b992beb0a85258430