### PR TITLE
Fix env usage in auth controller

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import { auth, db } from '../config/firebase.js';
+import { env } from '../config/env.js';
 
 
 export const register = async (req: Request, res: Response) => {
@@ -66,7 +67,7 @@ export const login = async (req: Request, res: Response) => {
 
     // Verify credentials using Firebase Auth REST API
     await axios.post(
-      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${.env.FIREBASE_API_KEY}`,
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${env.FIREBASE_API_KEY}`,
       { email, password, returnSecureToken: true }
     );
 


### PR DESCRIPTION
## Summary
- import env utilities in backend auth controller
- use env variable for Firebase API key

## Testing
- `npm run build`
- `npm run dev` *(fails: invalid environment variables)*
- `npx eslint "src/**/*.{ts,tsx}"` *(fails: cannot read properties of undefined from @typescript-eslint/no-unused-expressions)*

------
https://chatgpt.com/codex/tasks/task_e_6884dcf0a4b8832bbd6523bd74982126