### PR TITLE
Fix mobile styling of browse quizzes button

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -859,8 +859,9 @@ const Home = () => {
                       <CardDescription className="text-sm text-gray-600 dark:text-gray-300 break-words">{category.description}</CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <Button 
-                        className="w-full bg-blue-600 hover:bg-blue-700 text-white transition-colors duration-300" 
+                      <Button
+                        className="w-full bg-blue-600 hover:bg-blue-700 text-white transition-colors duration-300 text-xs sm:text-sm"
+                        size="sm"
                         variant="default"
                         onClick={() => !isAuthenticated ? navigate('/auth') : navigate(`/category/${category.id}/subcategories`)}
                       >


### PR DESCRIPTION
## Summary
- improve "Browse Quizzes" button visibility on small screens

## Testing
- `npm run lint` *(fails: `163 problems (143 errors, 20 warnings)`)*

------
https://chatgpt.com/codex/tasks/task_e_688635f36930832bae4eafd6a859f0b1