### PR TITLE
Disable daily challenges on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -57,6 +57,9 @@ const Home = () => {
   
   const { user, loading } = useContext(AuthContext);
   const isAuthenticated = user !== null;
+
+  // Toggle to enable/disable Daily Challenges section
+  const showDailyChallenges = false;
   
   const { data: quizCategories, isLoading: isLoadingCategories, error: categoriesError } = useQuery({
     queryKey: ['quiz-categories'],
@@ -71,6 +74,7 @@ const Home = () => {
   const { data: dailyChallenges, isLoading: isLoadingDailyChallenges, error: dailyChallengesError } = useQuery<DailyChallenge[]>({
     queryKey: ['daily-challenges-home'],
     queryFn: getDailyChallenges,
+    enabled: showDailyChallenges,
   });
 
   const { data: registrationStatus, isLoading: isLoadingRegistrations } = useQuery({
@@ -159,6 +163,7 @@ const Home = () => {
   });
 
   useEffect(() => {
+    if (!showDailyChallenges) return;
     const fetchStatuses = async () => {
       if (!user || !dailyChallenges) {
         setStatusLoading(false);
@@ -181,7 +186,7 @@ const Home = () => {
       }
     };
     fetchStatuses();
-  }, [user, dailyChallenges]);
+  }, [user, dailyChallenges, showDailyChallenges]);
 
   const handleStartChallenge = async (ch: DailyChallenge) => {
     if (!user) { toast.error('Please login first'); navigate('/auth'); return; }
@@ -681,6 +686,7 @@ const Home = () => {
           </div>
         </div>
 
+        {showDailyChallenges && (
         <div>
           <h2 className="text-2xl font-bold mb-6 flex items-center justify-center">
             <div className="relative group flex items-center">
@@ -765,6 +771,7 @@ const Home = () => {
             )}
           </div>
         </div>
+        )}
 
         <div>
           <h2 className="text-2xl font-bold mb-6 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- add flag to toggle Daily Challenges section
- hide the Daily Challenges block in the home page
- guard status fetch logic with the toggle

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68871298cbf4832b9a43addbf90dc57e