### PR TITLE
Add slug-based paid content pages

### DIFF
--- a/backend/src/controllers/paidContentController.ts
+++ b/backend/src/controllers/paidContentController.ts
@@ -14,6 +14,21 @@ export const getPaidContents = async (_req: Request, res: Response) => {
   }
 };
 
+export const getPaidContentBySlug = async (req: Request, res: Response) => {
+  try {
+    const { slug } = req.params;
+    const snapshot = await db.collection('paidContents').where('slug', '==', slug).limit(1).get();
+    if (snapshot.empty) {
+      return res.status(404).json({ error: 'Content not found' });
+    }
+    const doc = snapshot.docs[0];
+    res.json({ id: doc.id, ...doc.data() });
+  } catch (error) {
+    console.error('Error fetching paid content by slug:', error);
+    res.status(500).json({ error: 'Failed to fetch paid content' });
+  }
+};
+
 export const getPurchasedContent = async (req: Request, res: Response) => {
   try {
     const { userId } = req.params;

--- a/backend/src/routes/paidContentRoutes.ts
+++ b/backend/src/routes/paidContentRoutes.ts
@@ -1,8 +1,9 @@
 import express from 'express';
-import { getPaidContents, downloadPaidContent } from '../controllers/paidContentController.js';
+import { getPaidContents, getPaidContentBySlug, downloadPaidContent } from '../controllers/paidContentController.js';
 import { authenticateUser } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/', getPaidContents);
+router.get('/slug/:slug', getPaidContentBySlug);
 router.get('/:contentId/download', authenticateUser, downloadPaidContent);
 export default router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ const QuestionPaperCategory = React.lazy(() => import('./pages/QuestionPaperCate
 const AdminQuestionPaperCategories = React.lazy(() => import('./pages/admin/QuestionPaperCategories'));
 const AdminQuestionPapers = React.lazy(() => import('./pages/admin/QuestionPapers'));
 const PaidContent = React.lazy(() => import('./pages/PaidContent'));
+const PaidContentDetail = React.lazy(() => import('./pages/PaidContentDetail'));
 const PaidContentManager = React.lazy(() => import('./pages/admin/PaidContentManager'));
 const PurchasedContent = React.lazy(() => import('./pages/PurchasedContent'));
 const MaintenancePage = React.lazy(() => import('./pages/Maintenance'));
@@ -186,6 +187,7 @@ const AppContent: React.FC = () => {
       } />
       {/* Paid Content Routes */}
       <Route path="/paid-content" element={<PaidContent />} />
+      <Route path="/paid-content/:slug" element={<PaidContentDetail />} />
       <Route path="/purchased-content" element={
         <ProtectedRoute>
           <PurchasedContent />

--- a/src/pages/PaidContent.tsx
+++ b/src/pages/PaidContent.tsx
@@ -11,6 +11,7 @@ import { Link, useNavigate } from 'react-router-dom';
 interface PaidContent {
   id: string;
   title: string;
+  slug: string;
   description: string;
   price: number;
   pdfUrl: string;
@@ -146,6 +147,13 @@ export default function PaidContentPage() { // Renamed component to avoid confli
                     View Sample
                   </Button>
                 )}
+                <Button
+                  asChild
+                  variant="outline"
+                  className="w-full mb-2 border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-gray-600 dark:text-indigo-300 dark:hover:bg-gray-700"
+                >
+                  <Link to={`/paid-content/${content.slug}`}>View Details</Link>
+                </Button>
                 <Button
                   onClick={() => handlePurchase(content)}
                   className="w-full bg-indigo-600 hover:bg-indigo-700 text-white transition-colors duration-300"

--- a/src/pages/PaidContentDetail.tsx
+++ b/src/pages/PaidContentDetail.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../App';
+import { getPaidContentBySlug, purchaseContent, downloadContent, PaidContent } from '../services/api/paidContent';
+import { getUserBalance } from '../services/api/balance';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { toast } from 'sonner';
+import { ArrowLeft, FileText, Loader2 } from 'lucide-react';
+import { Helmet } from 'react-helmet';
+
+export default function PaidContentDetailPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [content, setContent] = useState<PaidContent | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (slug) {
+      fetchContent(slug);
+    }
+  }, [slug]);
+
+  const fetchContent = async (slugValue: string) => {
+    try {
+      const data = await getPaidContentBySlug(slugValue);
+      setContent(data);
+    } catch (err) {
+      console.error('Error fetching content:', err);
+      toast.error('Failed to load content');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePurchase = async (item: PaidContent) => {
+    if (!user) {
+      toast.error('Please login to purchase content');
+      navigate('/auth');
+      return;
+    }
+
+    try {
+      const balance = await getUserBalance(user.uid);
+      if (balance.amount < item.price) {
+        toast.error(`Insufficient balance. You need ₹${item.price}. Current balance: ₹${balance.amount}`);
+        return;
+      }
+
+      await purchaseContent(user.uid, item.id);
+      toast.success('Purchase successful!');
+
+      try {
+        const blob = await downloadContent(item.id);
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${item.title}.pdf`;
+        link.click();
+        window.URL.revokeObjectURL(url);
+      } catch (err) {
+        console.error('Failed to download file:', err);
+        toast.error('Unable to download file');
+      }
+    } catch (error) {
+      console.error('Error processing purchase:', error);
+      toast.error('Failed to process purchase');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex justify-center items-center bg-gradient-to-br from-white to-indigo-50 dark:from-gray-900 dark:to-gray-800">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-600" />
+      </div>
+    );
+  }
+
+  if (!content) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center">
+        <p className="text-gray-600 dark:text-gray-300 mb-4">Content not found.</p>
+        <Link to="/paid-content">
+          <Button variant="outline" className="gap-2">
+            <ArrowLeft className="h-4 w-4" /> Back
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-white to-indigo-50 dark:from-gray-900 dark:to-gray-800">
+      <Helmet>
+        <title>{content.title}</title>
+        <meta name="description" content={content.description} />
+      </Helmet>
+      <div className="container mx-auto px-4 py-12">
+        <div className="flex justify-start mb-8">
+          <Link to="/paid-content">
+            <Button variant="outline" className="gap-2 border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-gray-600 dark:text-indigo-300 dark:hover:bg-gray-700">
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Button>
+          </Link>
+        </div>
+        <Card className="max-w-2xl mx-auto">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold text-indigo-700 dark:text-indigo-400">{content.title}</CardTitle>
+            <CardDescription className="text-gray-600 dark:text-gray-300 mt-2">
+              {content.description}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {content.samplePdfUrl && (
+              <Button
+                variant="outline"
+                className="w-full border-indigo-300 text-indigo-700 hover:bg-indigo-50 dark:border-gray-600 dark:text-indigo-300 dark:hover:bg-gray-700"
+                onClick={() => window.open(content.samplePdfUrl!, '_blank')}
+              >
+                <FileText className="h-4 w-4 mr-2" /> View Sample
+              </Button>
+            )}
+            <Button
+              onClick={() => handlePurchase(content)}
+              className="w-full bg-indigo-600 hover:bg-indigo-700 text-white transition-colors duration-300"
+            >
+              Purchase for ₹{content.price}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/PurchasedContent.tsx
+++ b/src/pages/PurchasedContent.tsx
@@ -11,9 +11,10 @@ import { Skeleton } from '../components/ui/skeleton';
 interface PurchasedContent {
   id: string;
   title: string;
+  slug: string;
   description: string;
   pdfUrl: string;
-  purchaseDate?: string; 
+  purchaseDate?: string;
 }
 
 export default function PurchasedContentPage() { // Renamed component

--- a/src/pages/admin/PaidContentManager.tsx
+++ b/src/pages/admin/PaidContentManager.tsx
@@ -7,10 +7,12 @@ import { Input } from '../../components/ui/input';
 import { Textarea } from '../../components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { toast } from 'sonner';
+import { slugify } from '../../utils/slugify';
 
 interface PaidContent {
   id: string;
   title: string;
+  slug: string;
   description: string;
   price: number;
   pdfUrl: string;
@@ -93,6 +95,7 @@ export default function PaidContentManager() {
 
       // Add to Firestore
       const contentData = {
+        slug: slugify(newContent.title),
         title: newContent.title,
         description: newContent.description,
         price: Number(newContent.price),

--- a/src/services/api/paidContent.ts
+++ b/src/services/api/paidContent.ts
@@ -6,6 +6,7 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 export interface PaidContent {
   id: string;
   title: string;
+  slug: string;
   description: string;
   price: number;
   pdfUrl: string;
@@ -24,6 +25,14 @@ export const getPurchasedContents = async (userId: string): Promise<PaidContent[
   const token = await getAuthToken();
   const res = await axios.get(`${API_URL}/api/users/purchased-content/${userId}`, {
     headers: { Authorization: `Bearer ${token}` }
+  });
+  return res.data;
+};
+
+export const getPaidContentBySlug = async (slug: string): Promise<PaidContent> => {
+  const token = await getOptionalAuthToken();
+  const res = await axios.get(`${API_URL}/api/paid-contents/slug/${slug}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
   });
   return res.data;
 };


### PR DESCRIPTION
## Summary
- add `slug` to paid content data model
- generate slug when admins create paid content
- expose API endpoint to fetch paid content by slug
- add details page for paid content
- link paid content cards to new detail pages
- register `/paid-content/:slug` route

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `npm run build`
- `cd backend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b2c5a4a64832babf6d834267de30c