### PR TITLE
feat: improve SEO metadata and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>RajTest - High Quality Test Series and Megatests</title>
+    <title>RajTest</title>
     <meta name="description" content="High Quality Test Series and Megatests to win daily Prizes. Join our platform for competitive exam preparation and win exciting rewards." />
     <meta name="author" content="Rajtest" />
-
-    <!-- Canonical URL -->
-    <link rel="canonical" href="https://rajtest.com/" />
-
     <!-- Robots meta -->
     <meta name="robots" content="index, follow" />
-    
-    <!-- Additional SEO meta tags -->
-    <meta name="keywords" content="test series, competitive exams, online tests, exam preparation, daily prizes, megatests" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /admin/
 
 # Sitemap location
-Sitemap: https://rajtest.com/sitemap.xml 
+Sitemap: https://rajtest.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -55,4 +55,32 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-</urlset> 
+
+  <!-- Daily Top Rankers -->
+  <url>
+    <loc>https://rajtest.com/daily-top-rankers</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Daily Challenges -->
+  <url>
+    <loc>https://rajtest.com/daily-challenges</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Profile -->
+  <url>
+    <loc>https://rajtest.com/profile</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <!-- Authentication -->
+  <url>
+    <loc>https://rajtest.com/auth</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+</urlset>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,22 +1,48 @@
 import { Helmet } from 'react-helmet';
+import { useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { getSettings } from '@/services/api/settings';
+import { getSettings, PageSeo } from '@/services/api/settings';
 
-const Seo = () => {
+interface SeoProps {
+  title?: string;
+  description?: string;
+  keywords?: string;
+  canonical?: string; // relative or absolute URL
+}
+
+const Seo = ({ title, description, keywords, canonical }: SeoProps) => {
+  const location = useLocation();
   const { data: settings } = useQuery({
     queryKey: ['settings'],
     queryFn: getSettings
   });
 
+  const siteUrl = import.meta.env.VITE_SITE_URL || 'https://rajtest.com';
+  const path = location.pathname;
+  const pageSettings: PageSeo | undefined = settings?.pageSeo?.[path];
+
+  const resolvedTitle = title || pageSettings?.title || settings?.seoTitle;
+  const resolvedDescription =
+    description || pageSettings?.description || settings?.seoDescription;
+  const resolvedKeywords =
+    keywords || pageSettings?.keywords || settings?.seoKeywords;
+  const rawCanonical =
+    canonical || pageSettings?.canonical || path;
+
+  const canonicalUrl = rawCanonical
+    ? rawCanonical.startsWith('http')
+      ? rawCanonical
+      : `${siteUrl}${rawCanonical}`
+    : undefined;
+
   return (
     <Helmet>
-      {settings?.seoTitle && <title>{settings.seoTitle}</title>}
-      {settings?.seoDescription && (
-        <meta name="description" content={settings.seoDescription} />
+      {resolvedTitle && <title>{resolvedTitle}</title>}
+      {resolvedDescription && (
+        <meta name="description" content={resolvedDescription} />
       )}
-      {settings?.seoKeywords && (
-        <meta name="keywords" content={settings.seoKeywords} />
-      )}
+      {resolvedKeywords && <meta name="keywords" content={resolvedKeywords} />}
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     </Helmet>
   );
 };

--- a/src/components/admin/SEOManager.tsx
+++ b/src/components/admin/SEOManager.tsx
@@ -7,7 +7,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import type { PageSeo } from '@/services/api/settings';
+
+interface PageForm extends PageSeo {
+  path: string;
+}
 
 const SEOManager = () => {
   const queryClient = useQueryClient();
@@ -16,6 +21,7 @@ const SEOManager = () => {
     seoDescription: '',
     seoKeywords: ''
   });
+  const [pages, setPages] = useState<PageForm[]>([]);
 
   const { data: settings, isLoading } = useQuery({
     queryKey: ['admin-seo-settings'],
@@ -27,9 +33,10 @@ const SEOManager = () => {
           seoTitle?: string;
           seoDescription?: string;
           seoKeywords?: string;
+          pageSeo?: Record<string, PageSeo>;
         };
       }
-      return { seoTitle: '', seoDescription: '', seoKeywords: '' };
+      return { seoTitle: '', seoDescription: '', seoKeywords: '', pageSeo: {} };
     }
   });
 
@@ -40,33 +47,84 @@ const SEOManager = () => {
         seoDescription: settings.seoDescription || '',
         seoKeywords: settings.seoKeywords || ''
       });
+      const pageEntries = settings.pageSeo
+        ? Object.entries(settings.pageSeo).map(([path, data]) => ({
+            path,
+            title: data.title || '',
+            description: data.description || '',
+            keywords: data.keywords || '',
+            canonical: data.canonical || ''
+          }))
+        : [];
+      setPages(pageEntries);
     }
   }, [settings]);
 
   const mutation = useMutation({
-    mutationFn: async (data: typeof formState) => {
+    mutationFn: async (payload: {
+      seoTitle: string;
+      seoDescription: string;
+      seoKeywords: string;
+      pageSeo: Record<string, PageSeo>;
+    }) => {
       const docRef = doc(db, 'config', 'settings');
-      await setDoc(docRef, data, { merge: true });
+      await setDoc(docRef, payload, { merge: true });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin-seo-settings'] });
       queryClient.invalidateQueries({ queryKey: ['settings'] });
       toast.success('SEO settings updated');
     },
-    onError: (err) => {
+    onError: err => {
       console.error('Error updating SEO settings:', err);
       toast.error('Failed to update SEO settings');
     }
   });
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value } = e.target;
     setFormState(prev => ({ ...prev, [name]: value }));
   };
 
+  const handlePageChange = (
+    index: number,
+    field: keyof PageForm,
+    value: string
+  ) => {
+    setPages(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const addPage = () => {
+    setPages(prev => [
+      ...prev,
+      { path: '', title: '', description: '', keywords: '', canonical: '' }
+    ]);
+  };
+
+  const removePage = (index: number) => {
+    setPages(prev => prev.filter((_, i) => i !== index));
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    mutation.mutate(formState);
+    const pageSeo = pages.reduce<Record<string, PageSeo>>((acc, page) => {
+      if (page.path) {
+        acc[page.path] = {
+          title: page.title || undefined,
+          description: page.description || undefined,
+          keywords: page.keywords || undefined,
+          canonical: page.canonical || undefined
+        };
+      }
+      return acc;
+    }, {});
+    mutation.mutate({ ...formState, pageSeo });
   };
 
   if (isLoading) {
@@ -83,7 +141,7 @@ const SEOManager = () => {
         <CardTitle>SEO Settings</CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
             <label htmlFor="seoTitle" className="text-sm font-medium">
               Site Title
@@ -118,6 +176,56 @@ const SEOManager = () => {
               onChange={handleChange}
             />
           </div>
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium">Page Metadata</h3>
+              <Button type="button" onClick={addPage} size="sm" variant="outline">
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            {pages.map((page, idx) => (
+              <div key={idx} className="space-y-2 rounded-md border p-4">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium">Path</label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removePage(idx)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                <Input
+                  value={page.path}
+                  onChange={e => handlePageChange(idx, 'path', e.target.value)}
+                  placeholder="/example"
+                />
+                <Input
+                  value={page.title}
+                  onChange={e => handlePageChange(idx, 'title', e.target.value)}
+                  placeholder="Title"
+                />
+                <Textarea
+                  value={page.description}
+                  onChange={e => handlePageChange(idx, 'description', e.target.value)}
+                  placeholder="Description"
+                />
+                <Input
+                  value={page.keywords}
+                  onChange={e => handlePageChange(idx, 'keywords', e.target.value)}
+                  placeholder="Keywords"
+                />
+                <Input
+                  value={page.canonical}
+                  onChange={e => handlePageChange(idx, 'canonical', e.target.value)}
+                  placeholder="Canonical URL (optional)"
+                />
+              </div>
+            ))}
+          </div>
+
           <Button type="submit" disabled={mutation.isPending}>
             {mutation.isPending && (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/pages/AllMegaTests.tsx
+++ b/src/pages/AllMegaTests.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Clock, ListChecks, CreditCard, Trophy, Loader2 } from 'lucide-react';
-import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest, registerForMegaTest } from '@/services/api/megaTest';
+import { getMegaTests, isUserRegistered, hasUserSubmittedMegaTest, registerForMegaTest, MegaTest } from '@/services/api/megaTest';
 import { getMegaTestQuestionCount } from '@/services/firebase/quiz';
 import { parseTimestamp } from '@/utils/parseTimestamp';
 import { format } from 'date-fns';
@@ -15,6 +15,7 @@ import MegaTestParticipantsProgress from '../components/MegaTestParticipantsProg
 import { useState } from 'react';
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import Seo from '@/components/Seo';
 
 const AllMegaTests = () => {
   const navigate = useNavigate();
@@ -82,7 +83,7 @@ const AllMegaTests = () => {
     enabled: !!megaTests
   });
 
-  const getMegaTestStatus = (megaTest: any) => {
+  const getMegaTestStatus = (megaTest: MegaTest) => {
     const now = new Date();
     const registrationStart = parseTimestamp(megaTest.registrationStartTime);
     const registrationEnd = parseTimestamp(megaTest.registrationEndTime);
@@ -118,8 +119,12 @@ const AllMegaTests = () => {
       toast.success('Successfully registered for the mega test!');
       await queryClient.invalidateQueries({ queryKey: ['registrations', user.uid] });
       await queryClient.invalidateQueries({ queryKey: ['participant-count', megaTestId] });
-    } catch (error: any) {
-      const msg: string | undefined = error?.response?.data?.error || error.message;
+    } catch (err: unknown) {
+      const error = err as {
+        response?: { data?: { error?: string } };
+        message?: string;
+      };
+      const msg: string | undefined = error.response?.data?.error || error.message;
       if (error.message?.includes('Insufficient balance')) {
         toast.error(error.message);
         navigate('/profile');
@@ -156,22 +161,27 @@ const AllMegaTests = () => {
 
   if (isLoading) {
     return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-muted rounded w-1/4"></div>
-          <div className="h-4 bg-muted rounded w-1/2"></div>
-          <div className="space-y-2">
-            <div className="h-4 bg-muted rounded"></div>
-            <div className="h-4 bg-muted rounded"></div>
-            <div className="h-4 bg-muted rounded"></div>
+      <>
+        <Seo />
+        <div className="container mx-auto px-4 py-8">
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-muted rounded w-1/4"></div>
+            <div className="h-4 bg-muted rounded w-1/2"></div>
+            <div className="space-y-2">
+              <div className="h-4 bg-muted rounded"></div>
+              <div className="h-4 bg-muted rounded"></div>
+              <div className="h-4 bg-muted rounded"></div>
+            </div>
           </div>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <>
+      <Seo />
+      <div className="container mx-auto px-4 py-8">
       <Button
         variant="ghost"
         className="mb-6"
@@ -194,8 +204,8 @@ const AllMegaTests = () => {
         <ToggleGroupItem value="unregistered">Unregistered</ToggleGroupItem>
       </ToggleGroup>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {filteredMegaTests.map((megaTest) => {
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredMegaTests.map((megaTest) => {
           const participantCount = queryClient.getQueryData<number>(['participant-count', megaTest.id]);
           const seatsFull = megaTest.maxParticipants > 0 && (participantCount ?? 0) >= megaTest.maxParticipants;
           const status = getMegaTestStatus(megaTest);
@@ -314,8 +324,9 @@ const AllMegaTests = () => {
             </Card>
           );
         })}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/DailyTopRankers.tsx
+++ b/src/pages/DailyTopRankers.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { User } from 'lucide-react';
 import LoadingSpinner from '@/components/ui/loading-spinner';
+import Seo from '@/components/Seo';
 
 interface RankEntry extends DailyRankEntry {
   userName: string;
@@ -41,45 +42,51 @@ const DailyTopRankers = () => {
 
   if (isLoading || (data && data.length > 0 && entries.length === 0)) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <LoadingSpinner className="h-8 w-8 text-primary" />
-      </div>
+      <>
+        <Seo />
+        <div className="flex items-center justify-center min-h-screen">
+          <LoadingSpinner className="h-8 w-8 text-primary" />
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <Button variant="ghost" className="mb-6" onClick={() => navigate(-1)}>
-        Back
-      </Button>
-      <Card>
-        <CardHeader>
-          <CardTitle>Daily Top Rankers</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {entries.map((entry, idx) => (
-              <div
-                key={entry.userId}
-                className="flex items-center justify-between p-2 rounded-md bg-muted/50"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="font-bold w-4 text-right">{idx + 1}.</span>
-                  <User className="h-4 w-4 text-muted-foreground" />
-                  <span>{entry.userName}</span>
+    <>
+      <Seo />
+      <div className="container mx-auto px-4 py-8">
+        <Button variant="ghost" className="mb-6" onClick={() => navigate(-1)}>
+          Back
+        </Button>
+        <Card>
+          <CardHeader>
+            <CardTitle>Daily Top Rankers</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {entries.map((entry, idx) => (
+                <div
+                  key={entry.userId}
+                  className="flex items-center justify-between p-2 rounded-md bg-muted/50"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-bold w-4 text-right">{idx + 1}.</span>
+                    <User className="h-4 w-4 text-muted-foreground" />
+                    <span>{entry.userName}</span>
+                  </div>
+                  <span className="font-medium">
+                    ₹{entry.totalPrize.toLocaleString('en-IN')}
+                  </span>
                 </div>
-                <span className="font-medium">
-                  ₹{entry.totalPrize.toLocaleString('en-IN')}
-                </span>
-              </div>
-            ))}
-            {entries.length === 0 && (
-              <div className="text-center text-muted-foreground">No rankings yet</div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+              ))}
+              {entries.length === 0 && (
+                <div className="text-center text-muted-foreground">No rankings yet</div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -37,6 +37,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import RegistrationCountdown from '../components/RegistrationCountdown';
 import { getDeviceId } from '../utils/deviceId';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import Seo from '@/components/Seo';
 
 interface PaidContent {
   id: string;
@@ -160,7 +161,10 @@ const Home = () => {
       toast.success('Challenge started');
       navigate(`/daily-challenges/${id}`);
     },
-    onError: (err: any) => toast.error(err.response?.data?.error || 'Failed to start'),
+    onError: (err: unknown) => {
+      const error = err as { response?: { data?: { error?: string } } };
+      toast.error(error.response?.data?.error || 'Failed to start');
+    },
   });
 
   useEffect(() => {
@@ -207,9 +211,18 @@ const Home = () => {
     }
     setRegisteringId(megaTestId);
     try {
-      await registerMutation.mutateAsync({ megaTestId, userId: user.uid, username: user.displayName || '', email: user.email || '' });
-    } catch (error: any) {
-      const msg: string | undefined = error?.response?.data?.error || error.message;
+      await registerMutation.mutateAsync({
+        megaTestId,
+        userId: user.uid,
+        username: user.displayName || '',
+        email: user.email || ''
+      });
+    } catch (err: unknown) {
+      const error = err as {
+        response?: { data?: { error?: string } };
+        message?: string;
+      };
+      const msg: string | undefined = error.response?.data?.error || error.message;
       if (error.message?.includes('Insufficient balance')) {
         toast.error(error.message);
         navigate('/profile');
@@ -350,8 +363,10 @@ const Home = () => {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-4" onMouseMove={resetTimeout} onKeyDown={resetTimeout}>
-      <header className="sticky top-0 z-10 bg-background/70 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+    <>
+      <Seo />
+      <div className="min-h-screen bg-background text-foreground p-4" onMouseMove={resetTimeout} onKeyDown={resetTimeout}>
+        <header className="sticky top-0 z-10 bg-background/70 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
         <div className="container flex h-16 items-center justify-between py-4">
           <Link to="/" className="mr-4 flex items-center space-x-2">
             <Avatar className="h-8 w-8">
@@ -529,20 +544,24 @@ const Home = () => {
                   <ToggleGroupItem value="unregistered">Unregistered</ToggleGroupItem>
                 </ToggleGroup>
                 <Button
-                  onClick={() => navigate('/all-mega-tests')}
+                  asChild
                   className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-pink-400 focus:ring-offset-2"
                   aria-label="View All Mega Tests"
                 >
-                  View All Mega Tests
-                  <ArrowUpRight className="h-4 w-4" />
+                  <Link to="/all-mega-tests">
+                    View All Mega Tests
+                    <ArrowUpRight className="h-4 w-4" />
+                  </Link>
                 </Button>
                 <Button
-                  onClick={() => navigate('/daily-top-rankers')}
+                  asChild
                   className="flex items-center gap-2 px-4 py-1.5 font-bold rounded-full shadow-lg bg-gradient-to-r from-yellow-400 via-orange-500 to-amber-600 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2"
                   aria-label="Daily Top Rankers"
                 >
-                  <Trophy className="h-4 w-4" />
-                  Daily Top Rankers
+                  <Link to="/daily-top-rankers">
+                    <Trophy className="h-4 w-4" />
+                    Daily Top Rankers
+                  </Link>
                 </Button>
               </div>
             </div>
@@ -676,11 +695,13 @@ const Home = () => {
                       <>
                         <div className="flex items-center justify-center min-w-[200px] snap-center">
                           <Button
-                            onClick={() => navigate('/all-mega-tests')}
+                            asChild
                             className="flex items-center gap-2 px-4 py-2 font-bold rounded-full shadow-lg bg-gradient-to-r from-pink-500 via-yellow-400 to-green-400 text-white text-sm tracking-wide transition-all duration-300 hover:scale-105 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-pink-400 focus:ring-offset-2"
                           >
-                            View More MegaTests
-                            <ArrowUpRight className="h-4 w-4" />
+                            <Link to="/all-mega-tests">
+                              View More MegaTests
+                              <ArrowUpRight className="h-4 w-4" />
+                            </Link>
                           </Button>
                         </div>
                         <div className="min-w-8" />
@@ -994,6 +1015,7 @@ const Home = () => {
         </DialogContent>
       </Dialog>
     </div>
+    </>
   );
 };
 

--- a/src/services/api/settings.ts
+++ b/src/services/api/settings.ts
@@ -2,11 +2,19 @@ import axios from 'axios';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
+export interface PageSeo {
+  title?: string;
+  description?: string;
+  keywords?: string;
+  canonical?: string;
+}
+
 export interface SiteSettings {
   maintenanceMode?: boolean;
   seoTitle?: string;
   seoDescription?: string;
   seoKeywords?: string;
+  pageSeo?: Record<string, PageSeo>;
 }
 
 export const getSettings = async (): Promise<SiteSettings> => {


### PR DESCRIPTION
## Summary
- make SEO component configurable for per-page titles, descriptions, and canonicals
- remove global canonical and expand robots/sitemap for better crawling
- replace navigate() calls with crawlable links for major pages
- manage per-page SEO metadata through admin panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/components/Seo.tsx src/components/admin/SEOManager.tsx src/services/api/settings.ts src/pages/Index.tsx src/pages/AllMegaTests.tsx src/pages/DailyTopRankers.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688dc04aa0d8832baa63dd3556ff684f