### PR TITLE
feat: expand paid content details

### DIFF
--- a/src/pages/PaidContentDetails.tsx
+++ b/src/pages/PaidContentDetails.tsx
@@ -107,6 +107,15 @@ export default function PaidContentDetails() {
             </Button>
           </Link>
         </div>
+        {content.thumbnailUrl && (
+          <div className="flex justify-center mb-8">
+            <img
+              src={content.thumbnailUrl}
+              alt={content.title}
+              className="w-full max-w-2xl rounded-lg shadow-md"
+            />
+          </div>
+        )}
         <Card className="max-w-2xl mx-auto border-2 border-gray-200 dark:border-gray-700 bg-gradient-to-br from-white to-indigo-50 dark:from-gray-900 dark:to-gray-800">
           <CardHeader className="space-y-2">
             <CardTitle className="text-2xl font-bold text-indigo-700 dark:text-indigo-400">
@@ -135,6 +144,16 @@ export default function PaidContentDetails() {
                 <FileText className="h-4 w-4 mr-2" />
                 View Sample
               </Button>
+            )}
+            {content.highlights && content.highlights.length > 0 && (
+              <div>
+                <h3 className="text-lg font-semibold text-indigo-700 dark:text-indigo-400">What's Inside</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2 text-gray-700 dark:text-gray-300">
+                  {content.highlights.map((h, idx) => (
+                    <li key={idx}>{h}</li>
+                  ))}
+                </ul>
+              </div>
             )}
             <Button
               onClick={handlePurchase}

--- a/src/pages/admin/PaidContentManager.tsx
+++ b/src/pages/admin/PaidContentManager.tsx
@@ -16,6 +16,7 @@ interface PaidContent {
   pdfUrl: string;
   samplePdfUrl?: string;
   thumbnailUrl?: string;
+  highlights?: string[];
 }
 
 export default function PaidContentManager() {
@@ -24,6 +25,7 @@ export default function PaidContentManager() {
   const [newContent, setNewContent] = useState({
     title: '',
     description: '',
+    highlights: '',
     price: '',
     pdfFile: null as File | null,
     samplePdfFile: null as File | null,
@@ -95,6 +97,10 @@ export default function PaidContentManager() {
       const contentData = {
         title: newContent.title,
         description: newContent.description,
+        highlights: newContent.highlights
+          .split('\n')
+          .map(h => h.trim())
+          .filter(Boolean),
         price: Number(newContent.price),
         pdfUrl,
         samplePdfUrl: samplePdfUrl || null,
@@ -109,6 +115,7 @@ export default function PaidContentManager() {
       setNewContent({
         title: '',
         description: '',
+        highlights: '',
         price: '',
         pdfFile: null,
         samplePdfFile: null,
@@ -166,6 +173,15 @@ export default function PaidContentManager() {
                 value={newContent.description}
                 onChange={(e) => setNewContent(prev => ({ ...prev, description: e.target.value }))}
                 required
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Highlights (one per line)</label>
+              <Textarea
+                value={newContent.highlights}
+                onChange={(e) => setNewContent(prev => ({ ...prev, highlights: e.target.value }))}
+                placeholder={'Point 1\nPoint 2'}
               />
             </div>
             
@@ -228,6 +244,13 @@ export default function PaidContentManager() {
                 />
               )}
               <p className="text-gray-600 mb-2">{content.description}</p>
+              {content.highlights && content.highlights.length > 0 && (
+                <ul className="list-disc pl-5 mb-4 text-sm text-gray-700">
+                  {content.highlights.map((h, idx) => (
+                    <li key={idx}>{h}</li>
+                  ))}
+                </ul>
+              )}
               <p className="text-xl font-semibold mb-4">₹{content.price}</p>
               <div className="flex space-x-2">
                 <Button

--- a/src/services/api/paidContent.ts
+++ b/src/services/api/paidContent.ts
@@ -10,6 +10,8 @@ export interface PaidContent {
   price: number;
   pdfUrl: string;
   thumbnailUrl?: string;
+  samplePdfUrl?: string;
+  highlights?: string[];
 }
 
 export const getPaidContents = async (): Promise<PaidContent[]> => {


### PR DESCRIPTION
## Summary
- show paid content thumbnails and highlight lists on the details page
- allow admins to manage highlight bullet points for each paid content item
- expose new optional fields on paid content API interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unnecessary try/catch wrapper etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688f798f7734832b9e62f4211981bd48