### PR TITLE
feat: add question paper detail pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const Guide = React.lazy(() => import('./pages/Guide'));
 const MegaTestPrizesPage = React.lazy(() => import('./pages/MegaTestPrizes'));
 const QuestionPapers = React.lazy(() => import('./pages/QuestionPapers'));
 const QuestionPaperCategory = React.lazy(() => import('./pages/QuestionPaperCategory'));
+const QuestionPaperDetails = React.lazy(() => import('./pages/QuestionPaperDetails'));
 const AdminQuestionPaperCategories = React.lazy(() => import('./pages/admin/QuestionPaperCategories'));
 const AdminQuestionPapers = React.lazy(() => import('./pages/admin/QuestionPapers'));
 const PaidContent = React.lazy(() => import('./pages/PaidContent'));
@@ -175,6 +176,7 @@ const AppContent: React.FC = () => {
       {/* Question Paper Routes */}
       <Route path="/pyqs" element={<QuestionPapers />} />
       <Route path="/pyqs/:categorySlug" element={<QuestionPaperCategory />} />
+      <Route path="/pyqs/:categorySlug/:paperSlug" element={<QuestionPaperDetails />} />
       <Route path="/admin/question-paper-categories" element={
         <ProtectedRoute>
           <AdminQuestionPaperCategories />

--- a/src/pages/QuestionPaperCategory.tsx
+++ b/src/pages/QuestionPaperCategory.tsx
@@ -129,8 +129,13 @@ export default function QuestionPaperCategory() {
           <Card key={paper.id} className="group hover:shadow-lg transition-all duration-300">
             <CardHeader className="p-3 md:p-6">
               <div className="flex items-center justify-between">
-                <CardTitle className="text-base md:text-xl font-semibold group-hover:text-blue-600 transition-colors line-clamp-2">
-                  {paper.title}
+                <CardTitle className="text-base md:text-xl font-semibold line-clamp-2">
+                  <Link
+                    to={`/pyqs/${categorySlug}/${slugify(paper.title)}`}
+                    className="group-hover:text-blue-600 transition-colors"
+                  >
+                    {paper.title}
+                  </Link>
                 </CardTitle>
                 <FileText className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground flex-shrink-0" />
               </div>

--- a/src/pages/QuestionPaperDetails.tsx
+++ b/src/pages/QuestionPaperDetails.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { slugify } from '../utils/slugify';
+import { getQuestionPaperCategories, getQuestionPapersByCategory } from '../services/api/questionPapers';
+import type { QuestionPaper, QuestionPaperCategory } from '../services/api/questionPapers';
+import { ArrowLeft, Calendar, Download } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card';
+import Seo from '@/components/Seo';
+
+export default function QuestionPaperDetails() {
+  const { categorySlug, paperSlug } = useParams<{ categorySlug: string; paperSlug: string }>();
+  const navigate = useNavigate();
+  const [paper, setPaper] = useState<QuestionPaper | null>(null);
+  const [category, setCategory] = useState<QuestionPaperCategory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!categorySlug || !paperSlug) return;
+      try {
+        const categories = await getQuestionPaperCategories();
+        const currentCategory = categories.find(c => slugify(c.title) === categorySlug);
+        if (!currentCategory) {
+          setError('Category not found');
+          setLoading(false);
+          return;
+        }
+        setCategory(currentCategory);
+        const papers = await getQuestionPapersByCategory(currentCategory.id);
+        const currentPaper = papers.find(p => slugify(p.title) === paperSlug);
+        if (!currentPaper) {
+          setError('Paper not found');
+        } else {
+          setPaper(currentPaper);
+        }
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load paper');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [categorySlug, paperSlug]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  if (error || !paper || !category) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+        <p className="text-red-500">{error || 'Paper not found'}</p>
+        <Button onClick={() => navigate(`/pyqs/${categorySlug}`)}>Go Back</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Seo title={paper.title} description={paper.description} canonical={`/pyqs/${categorySlug}/${paperSlug}`} />
+      <div className="flex items-center gap-4 mb-8">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate(`/pyqs/${categorySlug}`)}
+          className="hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold">{paper.title}</h1>
+          <p className="text-muted-foreground mt-1 text-sm md:text-base">{category.title}</p>
+        </div>
+      </div>
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>{paper.title}</CardTitle>
+          <CardDescription>{paper.description}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>{paper.year}</span>
+          </div>
+          <Button asChild className="w-full">
+            <a href={paper.fileUrl} target="_blank" rel="noopener noreferrer">
+              <Download className="h-4 w-4 mr-2" />
+              Download PDF
+            </a>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- link individual question papers to dedicated pages
- add detail page for question papers with download link

## Testing
- `npm run lint` *(fails: Unexpected any, no-useless-catch, etc.)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890ce83d984832b9240689aa967b3ea