### PR TITLE
feat: restore scroll position

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { User as UserIcon, Book, LogOut } from 'lucide-react';
 import { api } from './api/config';
 import ProtectedRoute from './components/ProtectedRoute';
 import { getSettings } from './services/api/settings';
+import ScrollRestoration from './components/ScrollRestoration';
 const QuizCategories = React.lazy(() => import('./pages/QuizCategories'));
 const SubCategories = React.lazy(() => import('./pages/SubCategories'));
 const AllMegaTests = React.lazy(() => import('./pages/AllMegaTests'));
@@ -224,6 +225,7 @@ const App: React.FC = () => {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <Router>
+          <ScrollRestoration />
           <Toaster position="bottom-center" richColors />
           <Seo />
           <AppContent />

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigationType } from 'react-router-dom';
+
+const ScrollRestoration: React.FC = () => {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const key = `${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (navigationType === 'POP') {
+      const stored = sessionStorage.getItem(key);
+      if (stored) {
+        window.scrollTo(0, parseInt(stored, 10));
+        return;
+      }
+    }
+    window.scrollTo(0, 0);
+  }, [key, navigationType]);
+
+  useEffect(() => {
+    return () => {
+      sessionStorage.setItem(key, window.scrollY.toString());
+    };
+  }, [key]);
+
+  return null;
+};
+
+export default ScrollRestoration;


### PR DESCRIPTION
## Summary
- keep scroll location on back navigation using session storage
- wire up scroll restoration in the router

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type ...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d60c30a4832bb33a4a141e46c9fa